### PR TITLE
VCF Input + CRAM Updates

### DIFF
--- a/magma_ff/create_metawfr.py
+++ b/magma_ff/create_metawfr.py
@@ -831,7 +831,7 @@ class InputPropertiesFromSampleProcessing:
             meet
         :type requirements: dict
         :returns: UUIDs of found VCF files
-        :rtype: list(str)
+        :rtype: list
         :raises MetaWorkflowRunCreationError: If no VCF files meeting
             requirements found
         """
@@ -844,7 +844,7 @@ class InputPropertiesFromSampleProcessing:
                 f"No file with acceptable VCF file format meeting requirements found on"
                 f" SampleProcessing: {self.sample_processing}"
             )
-        return result
+        return [result]
 
     # SampleProcessing-specific properties
     @property

--- a/magma_ff/create_metawfr.py
+++ b/magma_ff/create_metawfr.py
@@ -577,22 +577,17 @@ def get_files_for_file_formats(file_items, file_formats, requirements=None):
     :returns: File UUIDs of files meeting file format and
         requirements
     :rtype: list(str)
-    :raises MetaWorkflowRunCreationError: If no files found to meet
-        file format/other requirements
     """
     result = []
     for file_item in file_items:
-        requirements_met = True
-        if requirements:
-            for key, accepted_values in requirements.items():
-                key_value = file_item.get(key)
-                if key_value not in accepted_values:
-                    requirements_met = False
-                    break
-        if requirements_met is False:
-            continue
         file_item_format = file_item.get(FILE_FORMAT, {}).get(FILE_FORMAT)
         if file_item_format in file_formats:
+            if requirements:
+                if not all(
+                    file_item.get(key) in accepted_values
+                    for key, accepted_values in requirements.items()
+                ):
+                    continue
             file_uuid = file_item.get(UUID)
             result.append(file_uuid)
     return result

--- a/magma_ff/create_metawfr.py
+++ b/magma_ff/create_metawfr.py
@@ -906,19 +906,19 @@ class InputPropertiesFromSampleProcessing:
     @property
     def input_vcfs(self):
         """VCFs submitted to the SampleProcessing."""
-        return self.get_submitted_vcfs()
+        return self.get_submitted_vcf_files()
 
     @property
     def input_snv_vcfs(self):
         """SNV VCFs submitted to the SampleProcessing."""
         requirements = {self.VARIANT_TYPE: [self.SNV_VARIANT_TYPE]}
-        return self.get_submitted_vcfs(requirements=requirements)
+        return self.get_submitted_vcf_files(requirements=requirements)
 
     @property
     def input_sv_vcfs(self):
         """SV VCFs submitted to the SampleProcessing."""
         requirements = {self.VARIANT_TYPE: [self.SV_VARIANT_TYPE]}
-        return self.get_submitted_vcfs(requirements=requirements)
+        return self.get_submitted_vcf_files(requirements=requirements)
 
     # Properties from Samples
     @property

--- a/magma_ff/create_metawfr.py
+++ b/magma_ff/create_metawfr.py
@@ -211,8 +211,6 @@ class MetaWorkflowRunFromSampleProcessing(MetaWorkflowRunFromItem):
         "samples.files.related_files.file.uuid",
         "samples.files.related_files.file.file_format.file_format",
         "samples.files.related_files.file.paired_end",
-        "samples.cram_files.uuid",
-        "samples.cram_files.file_format.file_format",
         "samples.processed_files.uuid",
         "samples.processed_files.paired_end",
         "samples.processed_files.file_format.file_format",
@@ -309,8 +307,6 @@ class MetaWorkflowRunFromSample(MetaWorkflowRunFromItem):
         "files.related_files.file.uuid",
         "files.related_files.file.file_format.file_format",
         "files.related_files.file.paired_end",
-        "cram_files.uuid",
-        "cram_files.file_format.file_format",
         "processed_files.uuid",
         "processed_files.paired_end",
         "processed_files.file_format.file_format",
@@ -952,7 +948,6 @@ class InputPropertiesFromSample:
     BAM_SAMPLE_ID = "bam_sample_id"
     PROCESSED_FILES = "processed_files"
     FILES = "files"
-    CRAM_FILES = "cram_files"
     RELATED_FILES = "related_files"
     FILE_FORMAT = "file_format"
     PAIRED_END = "paired_end"

--- a/magma_ff/create_metawfr.py
+++ b/magma_ff/create_metawfr.py
@@ -21,6 +21,10 @@ from magma_ff.metawflrun import MetaWorkflowRun
 from magma_ff.utils import make_embed_request
 
 
+FILE_FORMAT = "file_format"
+UUID = "uuid"
+
+
 ################################################
 #   MetaWorkflowRunCreationError
 ################################################
@@ -208,9 +212,12 @@ class MetaWorkflowRunFromSampleProcessing(MetaWorkflowRunFromItem):
         "samples.files.related_files.file.file_format.file_format",
         "samples.files.related_files.file.paired_end",
         "samples.cram_files.uuid",
+        "samples.cram_files.file_format.file_format",
         "samples.processed_files.uuid",
         "samples.processed_files.paired_end",
         "samples.processed_files.file_format.file_format",
+        "files.uuid",
+        "files.file_format.file_format",
     ]
 
     def __init__(
@@ -303,6 +310,7 @@ class MetaWorkflowRunFromSample(MetaWorkflowRunFromItem):
         "files.related_files.file.file_format.file_format",
         "files.related_files.file.paired_end",
         "cram_files.uuid",
+        "cram_files.file_format.file_format",
         "processed_files.uuid",
         "processed_files.paired_end",
         "processed_files.file_format.file_format",
@@ -558,6 +566,40 @@ class MetaWorkflowRunInput:
         return result
 
 
+def get_files_for_file_formats(file_items, file_formats, requirements=None):
+    """Gather file UUIDs for File items matching the file format
+    and meeting the requirements.
+
+    :param file_formats: Accepted formats of files to get
+    :type file_formats: list or set
+    :param requirements: Requirements a file must meet in order to
+        be acceptable, as key, value pairs of property names, lists
+        of acceptable property values
+    :type requirements: dict
+    :returns: File UUIDs of files meeting file format and
+        requirements
+    :rtype: list(str)
+    :raises MetaWorkflowRunCreationError: If no files found to meet
+        file format/other requirements
+    """
+    result = []
+    for file_item in file_items:
+        requirements_met = True
+        if requirements:
+            for key, accepted_values in requirements.items():
+                key_value = file_item.get(key)
+                if key_value not in accepted_values:
+                    requirements_met = False
+                    break
+        if requirements_met is False:
+            continue
+        file_item_format = file_item.get(FILE_FORMAT, {}).get(FILE_FORMAT)
+        if file_item_format in file_formats:
+            file_uuid = file_item.get(UUID)
+            result.append(file_uuid)
+    return result
+
+
 ################################################
 #   InputPropertiesFromSampleProcessing
 ################################################
@@ -579,9 +621,14 @@ class InputPropertiesFromSampleProcessing:
     PARENTS = "parents"
     SAMPLE_NAME = "sample_name"
     SEX = "sex"
+    FILES = "files"
+    FILE_FORMAT = "file_format"
 
     # Class constants
     GENDER = "gender"
+    VCF_GZ_FORMAT = "vcf_gz"
+    VCF_FORMAT = "vcf"
+    VCF_FORMATS = set([VCF_GZ_FORMAT, VCF_FORMAT])
 
     def __init__(
         self,
@@ -878,6 +925,18 @@ class InputPropertiesFromSampleProcessing:
         """Sorted names for created RckTar files input."""
         return self.get_property_from_samples("rcktar_file_names")
 
+    @property
+    def input_vcfs(self):
+        """VCFs submitted to the SampleProcessing."""
+        submitted_files = self.sample_processing.get(self.FILES, [])
+        result = get_files_for_file_formats(submitted_files, self.VCF_FORMATS)
+        if not result:
+            raise MetaWorkflowRunCreationError(
+                f"No file with acceptable VCF file format found on SampleProcessing:"
+                f" {self.sample_processing}"
+            )
+        return result
+
 
 class InputPropertiesFromSample:
     """Class for accessing MetaWorkflowRun input arguments from a
@@ -918,7 +977,7 @@ class InputPropertiesFromSample:
         """
         self.sample = sample
 
-    def get_processed_file_for_format(self, file_format, requirements=None):
+    def get_processed_files_for_file_format(self, file_format, requirements=None):
         """Get all files matching given file format on given sample
         that meet the given requirements.
 
@@ -928,30 +987,40 @@ class InputPropertiesFromSample:
             be acceptable, as key, value pairs of property names, lists
             of acceptable property values
         :type requirements: dict
-        :return: Processed file UUIDs of files meeting file format and
+        :returns: Processed file UUIDs of files meeting file format and
             requirements
         :rtype: list(str)
-        :raises MetaWorkflowRunCreationError: If no files found to meet
-            file format/other requirements
         """
         result = []
         processed_files = self.sample.get(self.PROCESSED_FILES, [])
-        for processed_file in processed_files:
-            requirements_met = True
-            if requirements:
-                for key, accepted_values in requirements.items():
-                    key_value = processed_file.get(key)
-                    if key_value not in accepted_values:
-                        requirements_met = False
-                        break
-            if requirements_met is False:
-                continue
-            processed_file_format = processed_file.get(self.FILE_FORMAT, {}).get(
-                self.FILE_FORMAT
+        result = get_files_for_file_formats(
+            processed_files, [file_format], requirements=requirements
+        )
+        if not result:
+            raise MetaWorkflowRunCreationError(
+                "No file with format %s meeting requirements %s found on Sample: %s"
+                % (file_format, requirements, self.sample)
             )
-            if processed_file_format == file_format:
-                file_uuid = processed_file.get(self.UUID)
-                result.append(file_uuid)
+        return result
+
+    def get_submitted_files_for_file_format(self, file_format, requirements=None):
+        """Get all submitted file UUIDs matching file format and meeting
+        requirements.
+
+        :param file_format: Format of files to get
+        :type file_format: str
+        :param requirements: Requirements a file must meet in order to
+            be acceptable, as key, value pairs of property names, lists
+            of acceptable property values
+        :type requirements: dict
+        :returns: Submitted file UUIDs of files meeting file format and
+            requirements
+        :rtype: list(str)
+        """
+        submitted_files = self.sample.get(self.FILES, [])
+        result = get_files_for_file_formats(
+            submitted_files, [file_format], requirements=requirements
+        )
         if not result:
             raise MetaWorkflowRunCreationError(
                 "No file with format %s meeting requirements %s found on Sample: %s"
@@ -1019,35 +1088,20 @@ class InputPropertiesFromSample:
 
         if not paired_end_fastqs:  # May have come from CRAM conversion
             requirements = {self.PAIRED_END: [paired_end]}
-            paired_end_fastqs = self.get_processed_file_for_format(
+            paired_end_fastqs = self.get_processed_files_for_file_format(
                 self.FASTQ_FORMAT, requirements=requirements
             )
         return paired_end_fastqs
 
     @property
     def input_crams(self):
-        """Get CRAM files for each Sample.
-
-        :return: CRAM UUIDs for all CRAM files found on all Samples
-        :rtype: dict
-        :raises MetaWorkflowRunCreationError: If no CRAM files could be
-            found on a Sample
-        """
-        cram_uuids = []
-        cram_files = self.sample.get(self.CRAM_FILES)
-        if cram_files is None:
-            raise MetaWorkflowRunCreationError(
-                "Tried to grab CRAM files from a Sample lacking them: %s" % self.sample
-            )
-        for cram_file in cram_files:
-            cram_uuid = cram_file.get(self.UUID)
-            cram_uuids.append(cram_uuid)
-        return [cram_uuids]
+        """CRAM file input."""
+        return [self.get_submitted_files_for_file_format(self.CRAM_FORMAT)]
 
     @property
     def input_gvcfs(self):
         """gVCF file input."""
-        return [self.get_processed_file_for_format(self.GVCF_FORMAT)]
+        return [self.get_processed_files_for_file_format(self.GVCF_FORMAT)]
 
     @property
     def fastqs_r1(self):
@@ -1074,7 +1128,7 @@ class InputPropertiesFromSample:
     @property
     def input_bams(self):
         """BAM file input."""
-        return [self.get_processed_file_for_format(self.BAM_FORMAT)]
+        return [self.get_processed_files_for_file_format(self.BAM_FORMAT)]
 
     @property
     def rcktar_file_names(self):

--- a/magma_ff/create_metawfr.py
+++ b/magma_ff/create_metawfr.py
@@ -570,6 +570,8 @@ def get_files_for_file_formats(file_items, file_formats, requirements=None):
     """Gather file UUIDs for File items matching the file format
     and meeting the requirements.
 
+    :param file_items: The files to sort through
+    :type file_items: list(dict)
     :param file_formats: Accepted formats of files to get
     :type file_formats: list or set
     :param requirements: Requirements a file must meet in order to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-suite"
-version = "1.0.1"
+version = "1.1.0"
 description = "Collection of tools to manage meta-workflows automation."
 authors = ["Michele Berselli <berselli.michele@gmail.com>", "Doug Rioux", "Soo Lee", "CGAP team"]
 license = "MIT"

--- a/test/test_create_metawfr_ff.py
+++ b/test/test_create_metawfr_ff.py
@@ -1047,9 +1047,9 @@ class TestInputPropertiesFromSampleProcessing:
             ("fastqs_r1", FASTQ_R1_UUIDS),
             ("input_bams", BAM_UUIDS),
             ("input_gvcfs", GVCF_UUIDS),
-            ("input_vcfs", VCF_UUIDS),
-            ("input_snv_vcfs", [SNV_VCF_UUID]),
-            ("input_sv_vcfs", [SV_VCF_UUID]),
+            ("input_vcfs", [VCF_UUIDS]),
+            ("input_snv_vcfs", [[SNV_VCF_UUID]]),
+            ("input_sv_vcfs", [[SV_VCF_UUID]]),
         ],
     )
     def test_attributes(self, attribute, expected, inputs_from_sample_processing):
@@ -1062,7 +1062,7 @@ class TestInputPropertiesFromSampleProcessing:
         [
             (None, []),
             ({"foo": ["bur"]}, []),
-            ({"foo": ["bur"]}, [VCF_UUIDS]),
+            ({"foo": ["bur"]}, VCF_UUIDS),
         ],
     )
     def test_get_submitted_vcf_files(
@@ -1081,7 +1081,7 @@ class TestInputPropertiesFromSampleProcessing:
                 result = inputs_from_sample_processing.get_submitted_vcf_files(
                     requirements
                 )
-                assert result == return_value
+                assert result == [return_value]
             mocked_get_files_for_file_formats.assert_called_once_with(
                 SAMPLE_PROCESSING_SUBMITTED_FILES,
                 InputPropertiesFromSampleProcessing.VCF_FORMATS,

--- a/test/test_create_metawfr_ff.py
+++ b/test/test_create_metawfr_ff.py
@@ -503,7 +503,9 @@ META_WORKFLOW_RUN_FOR_SAMPLE_3 = {
 }
 VCF_1_UUID = "some_vcf"
 VCF_1_FILE_METADATA = {
-    "uuid": VCF_1_UUID, "file_format": {"file_format": "vcf_gz"}, "foo": "bar"
+    "uuid": VCF_1_UUID,
+    "file_format": {"file_format": "vcf_gz"},
+    "foo": "bar",
 }
 VCF_2_UUID = "some_other_vcf"
 VCF_2_FILE_METADATA = {"uuid": VCF_2_UUID, "file_format": {"file_format": "vcf"}}
@@ -854,7 +856,7 @@ class TestMetaWorkflowRunInput:
         (FILES_MULTIPLE_VCFS, ["bar", "vcf"], None, [SOME_FILE_UUID, VCF_2_UUID]),
         (FILES_MULTIPLE_VCFS, ["vcf_gz"], {"foo": ["value"]}, []),
         (FILES_MULTIPLE_VCFS, ["vcf_gz"], {"foo": ["bar"]}, [VCF_1_UUID]),
-    ]
+    ],
 )
 def test_get_files_for_file_formats(file_items, file_formats, requirements, expected):
     """Test gather of file UUIDs based on file formats and property
@@ -1043,7 +1045,7 @@ class TestInputPropertiesFromSampleProcessing:
             (FILES_NO_VCF, []),
             (FILES_ONE_VCF, [VCF_1_UUID]),
             (FILES_MULTIPLE_VCFS, [VCF_1_UUID, VCF_2_UUID]),
-        ]
+        ],
     )
     def test_input_vcfs(self, files, expected):
         """Test collection of VCFs submitted to SampleProcessing."""
@@ -1171,7 +1173,7 @@ class TestInputPropertiesFromSample:
             ("rcktar_file_names", SAMPLE_3_RCKTARS),
             ("sample_names", SAMPLE_3_NAMES),
             ("input_sample_uuids", SAMPLE_3_UUIDS),
-        ]
+        ],
     )
     def test_attributes(self, attribute, expected, inputs_from_sample):
         """Test properties on class."""

--- a/test/test_create_metawfr_ff.py
+++ b/test/test_create_metawfr_ff.py
@@ -1047,6 +1047,9 @@ class TestInputPropertiesFromSampleProcessing:
             ("fastqs_r1", FASTQ_R1_UUIDS),
             ("input_bams", BAM_UUIDS),
             ("input_gvcfs", GVCF_UUIDS),
+            ("input_vcfs", VCF_UUIDS),
+            ("input_snv_vcfs", [SNV_VCF_UUID]),
+            ("input_sv_vcfs", [SV_VCF_UUID]),
         ],
     )
     def test_attributes(self, attribute, expected, inputs_from_sample_processing):


### PR DESCRIPTION
This PR updates the MetaWorkflowRun creation module with the following:

- New input arg `input_vcfs` to grab submitted VCFs to a SampleProcessing
- Refactors `input_crams` due to recent portal schema updates

Some minor additional refactoring was done to share code across classes, and tests were updated as well.