### PR TITLE
SampleProcessing Inputs + File Dimensionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-suite"
-version = "1.2.0"
+version = "1.2.1"
 description = "Collection of tools to manage meta-workflows automation."
 authors = ["Michele Berselli <berselli.michele@gmail.com>", "Doug Rioux", "Soo Lee", "CGAP team"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-suite"
-version = "1.1.0"
+version = "1.1.1"
 description = "Collection of tools to manage meta-workflows automation."
 authors = ["Michele Berselli <berselli.michele@gmail.com>", "Doug Rioux", "Soo Lee", "CGAP team"]
 license = "MIT"

--- a/test/test_create_metawfr_ff.py
+++ b/test/test_create_metawfr_ff.py
@@ -67,6 +67,7 @@ SAMPLE_UUID_2 = "uuid_2"
 SAMPLE_UUID_3 = "uuid_3"
 SAMPLE_UUID_4 = "uuid_4"
 SORTED_SAMPLE_UUIDS = [SAMPLE_UUID_3, SAMPLE_UUID_4, SAMPLE_UUID_2, SAMPLE_UUID_1]
+RCKTAR_FILE_NAMES = [f"{sample_name}.rck.gz" for sample_name in SORTED_SAMPLE_NAMES]
 SAMPLE_1 = {
     "uuid": SAMPLE_UUID_1,
     "bam_sample_id": SAMPLE_NAME_1,
@@ -1070,6 +1071,7 @@ class TestInputPropertiesFromSampleProcessing:
             ("input_vcfs", [VCF_UUIDS]),
             ("input_snv_vcfs", [[SNV_VCF_UUID]]),
             ("input_sv_vcfs", [[SV_VCF_UUID]]),
+            ("rcktar_file_names", RCKTAR_FILE_NAMES),
         ],
     )
     def test_attributes(self, attribute, expected, inputs_from_sample_processing):

--- a/test/test_create_metawfr_ff.py
+++ b/test/test_create_metawfr_ff.py
@@ -45,9 +45,16 @@ FASTQ_R1_UUIDS = [
     [FASTQ_R1_UUID_1, FASTQ_R1_UUID_1_2],
 ]
 FASTQ_R2_UUID_1 = "fastq_r2_sample_1"
+FASTQ_R2_UUID_1_2 = "fastq_r2_sample_1_2"
 FASTQ_R2_UUID_2 = "fastq_r2_sample_2"
 FASTQ_R2_UUID_3 = "fastq_r2_sample_3"
 FASTQ_R2_UUID_4 = "fastq_r2_sample_4"
+FASTQ_R2_UUIDS = [
+    [FASTQ_R2_UUID_3],
+    [FASTQ_R2_UUID_4],
+    [FASTQ_R2_UUID_2],
+    [FASTQ_R2_UUID_1, FASTQ_R2_UUID_1_2],
+]
 PROJECT = "/projects/cgap-core/"
 INSTITUTION = "/institutions/hms-dbmi/"
 SAMPLE_NAME_1 = "SAMPLE1-DNA-WGS"
@@ -80,6 +87,11 @@ SAMPLE_1 = {
         },
         {
             "uuid": FASTQ_R2_UUID_1,
+            "paired_end": "2",
+            "file_format": {"file_format": "fastq"},
+        },
+        {
+            "uuid": FASTQ_R2_UUID_1_2,
             "paired_end": "2",
             "file_format": {"file_format": "fastq"},
         },
@@ -1052,6 +1064,7 @@ class TestInputPropertiesFromSampleProcessing:
             ("input_sample_uuids", SORTED_SAMPLE_UUIDS),
             ("input_crams", INPUT_CRAMS),
             ("fastqs_r1", FASTQ_R1_UUIDS),
+            ("fastqs_r2", FASTQ_R2_UUIDS),
             ("input_bams", BAM_UUIDS),
             ("input_gvcfs", GVCF_UUIDS),
             ("input_vcfs", [VCF_UUIDS]),
@@ -1180,7 +1193,7 @@ class TestInputPropertiesFromSample:
         [
             (SAMPLE_1, "0", True, None),
             (SAMPLE_1, "1", False, [FASTQ_R1_UUID_1, FASTQ_R1_UUID_1_2]),
-            (SAMPLE_1, "2", False, [FASTQ_R2_UUID_1]),
+            (SAMPLE_1, "2", False, [FASTQ_R2_UUID_1, FASTQ_R2_UUID_1_2]),
             (SAMPLE_2, "1", False, [FASTQ_R1_UUID_2]),
             (SAMPLE_2, "2", False, [FASTQ_R2_UUID_2]),
         ],

--- a/test/test_create_metawfr_ff.py
+++ b/test/test_create_metawfr_ff.py
@@ -666,13 +666,20 @@ class TestMetaWorkflowRunInput:
             ("foo", [], 1, False, []),
             (
                 "input_files",
-                [["file_1"], ["file_2"]],
+                [["file_1", "file_2"]],
                 1,
                 False,
                 [
                     {"file": "file_1", "dimension": "0"},
                     {"file": "file_2", "dimension": "1"},
                 ],
+            ),
+            (
+                "input_files",
+                [["file_1"], ["file_2"]],
+                1,
+                True,
+                [],
             ),
             (
                 "input_files",


### PR DESCRIPTION
Here, we fix the bug in capturing R2 FASTQ input from a SampleProcessing and refactor how file dimensionality is handled. Additionally, we add tests for the above as well as other untested properties on SampleProcessing inputs.