### PR TITLE
CohortAnalysis MWFRs

### DIFF
--- a/magma_ff/create_metawfr.py
+++ b/magma_ff/create_metawfr.py
@@ -655,9 +655,12 @@ class MetaWorkflowRunInput:
     ) -> List[JsonObject]:
         """Create one structured file input for MetaWorkflowRun[json].
 
-        File inputs arrive as lists of lists of UUIDs. For dimension 1,
-        each sub-list should contain <= 1 UUID. For dimension 2, any
-        number of UUIDs can be in each sub-list.
+        File inputs arrive as lists of lists of UUIDs for now. For
+        dimension 1, each sub-list should contain <= 1 UUID. For
+        dimension 2, any number of UUIDs can be in each sub-list.
+
+        To add more dimensions, will need to refactor inputs and this
+        method.
 
         :param file_parameter: Name of file input argument
         :param file_input_value: File input values

--- a/magma_ff/create_metawfr.py
+++ b/magma_ff/create_metawfr.py
@@ -85,7 +85,7 @@ def create_meta_workflow_run_from_sample(
     post: bool = True,
     patch: bool = True,
 ) -> JsonObject:
-    return _create_meta_workflow_run(
+    return _create_meta_workflow_run_for_item_type(
         MetaWorkflowRunFromSample,
         sample_identifier,
         meta_workflow_identifier,
@@ -102,7 +102,7 @@ def create_meta_workflow_run_from_sample_processing(
     post: bool = True,
     patch: bool = True,
 ) -> JsonObject:
-    return _create_meta_workflow_run(
+    return _create_meta_workflow_run_for_item_type(
         MetaWorkflowRunFromSampleProcessing,
         sample_processing_identifier,
         meta_workflow_identifier,
@@ -119,7 +119,7 @@ def create_meta_workflow_run_from_cohort_analysis(
     post: bool = True,
     patch: bool = True,
 ) -> JsonObject:
-    return _create_meta_workflow_run(
+    return _create_meta_workflow_run_for_item_type(
         MetaWorkflowRunFromCohortAnalysis,
         cohort_analysis_identifier,
         meta_workflow_identifier,
@@ -129,7 +129,7 @@ def create_meta_workflow_run_from_cohort_analysis(
     )
 
 
-def _create_meta_workflow_run(
+def _create_meta_workflow_run_for_item_type(
     meta_workflow_run_creator_class: MetaWorkflowRunFromItem,
     item_identifier: str,
     meta_workflow_identifier: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-suite"
-version = "1.3.0"
+version = "1.4.0"
 description = "Collection of tools to manage meta-workflows automation."
 authors = ["Michele Berselli <berselli.michele@gmail.com>", "Doug Rioux", "Soo Lee", "CGAP team"]
 license = "MIT"


### PR DESCRIPTION
Here, we add functionality for creating MetaWorkflowRuns on CohortAnalysis items. Currently, only 1 input is available, but more will be added shortly as required for Regenie pipeline.

Also, we fix handling of file inputs for dimensionality 1. I had refactored this method at some point in the past ~6 months for reasons that made sense to me then but I cannot now recall. This has not been an issue since we've been running entirely proband-only stuff for awhile, but the code has been reverted for this method and added further error handling. We tested this reversion by creating common MWFRs on various items, and everything seems alright with the reversion, but there have been a good reason for the previous change that will cause issues yet again...