### PR TITLE
Automated MetaWorkflowRun creation from file sets

### DIFF
--- a/magma_ff/wfrutils.py
+++ b/magma_ff/wfrutils.py
@@ -94,7 +94,7 @@ class FFWfrUtils(object):
             wfr_uuid = job_info.get('WorkflowRun uuid', '')
             if not wfr_uuid:
                 return None
-            self._metadata[job_id] = ff_utils.get_metadata(wfr_uuid, key=self.ff_key)
+            self._metadata[job_id] = ff_utils.get_metadata(wfr_uuid, add_on="frame=raw&datastore=database", key=self.ff_key)
             return self._metadata[job_id]
 
     @property

--- a/magma_smaht/commands/create_meta_workflow_run.py
+++ b/magma_smaht/commands/create_meta_workflow_run.py
@@ -20,7 +20,7 @@ from magma_smaht.utils import get_auth_key
     "--length-required",
     required=True,
     type=int,
-    help="Requried length (can be obtained from FastQC output)",
+    help="Required length (can be obtained from FastQC output)",
 )
 @click.option(
     "-e",
@@ -30,7 +30,7 @@ from magma_smaht.utils import get_auth_key
     help="Name of environment in smaht-keys file",
 )
 def mwfr_illumina_alignment_cmd(fileset_accession, length_required, auth_env):
-    """Creates a MetaWorflowRun item in the portal for Illumina alignemnt of submitted files within a file set"""
+    """Creates a MetaWorflowRun item in the portal for Illumina alignment of submitted files within a fileset"""
     smaht_key = get_auth_key(auth_env)
     mwfr_illumina_alignment(fileset_accession, length_required, smaht_key)
 
@@ -48,7 +48,7 @@ def mwfr_illumina_alignment_cmd(fileset_accession, length_required, auth_env):
     help="Name of environment in smaht-keys file",
 )
 def mwfr_pacbio_alignment_cmd(fileset_accession, auth_env):
-    """Creates a MetaWorflowRun item in the portal for Pacbio alignment of submitted files within a file set"""
+    """Creates a MetaWorflowRun item in the portal for PacBio alignment of submitted files within a fileset"""
     smaht_key = get_auth_key(auth_env)
     mwfr_pacbio_alignment(fileset_accession, smaht_key)
 
@@ -66,7 +66,7 @@ def mwfr_pacbio_alignment_cmd(fileset_accession, auth_env):
     help="Name of environment in smaht-keys file",
 )
 def mwfr_hic_alignment_cmd(fileset_accession, auth_env):
-    """Creates a MetaWorflowRun item in the portal for HIC alignment of submitted files within a file set"""
+    """Creates a MetaWorflowRun item in the portal for HIC alignment of submitted files within a fileset"""
     smaht_key = get_auth_key(auth_env)
     mwfr_hic_alignment(fileset_accession, smaht_key)
 
@@ -84,7 +84,7 @@ def mwfr_hic_alignment_cmd(fileset_accession, auth_env):
     help="Name of environment in smaht-keys file",
 )
 def mwfr_ont_alignment_cmd(fileset_accession, auth_env):
-    """Creates a MetaWorflowRun item in the portal for ONT alignment of submitted files within a file set"""
+    """Creates a MetaWorflowRun item in the portal for ONT alignment of submitted files within a fileset"""
     smaht_key = get_auth_key(auth_env)
     mwfr_ont_alignment(fileset_accession, smaht_key)
 

--- a/magma_smaht/commands/create_meta_workflow_run.py
+++ b/magma_smaht/commands/create_meta_workflow_run.py
@@ -1,42 +1,107 @@
-import argparse
+import click
 
-from magma_smaht.create_metawfr import create_meta_workflow_run
+from magma_smaht.create_metawfr import (
+    mwfr_illumina_alignment,
+    mwfr_pacbio_alignment,
+    mwfr_fastqc,
+    mwfr_hic_alignment,
+    mwfr_ont_alignment,
+)
 from magma_smaht.utils import get_auth_key
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Create MetaWorkflowRun")
-    parser.add_argument(
-        "input_item_identifier",
-        help="Identifier for item (e.g. Sample) for input to MetaWorkflowRun",
-    )
-    parser.add_argument(
-        "meta_workflow_identifier",
-        help="MetaWorkflow identifier for input to MetaWorkflowRun",
-    )
-    parser.add_argument(
-        "-e", "--auth-env", default="default", help="Env name in ~/.smaht-keys.json"
-    )
-    parser.add_argument(
-        "--no-post", action="store_true", help="Do not POST the MetaWorkflowRun created"
-    )
-    parser.add_argument(
-        "--no-patch",
-        action="store_true",
-        help="Do not PATCH the input item with the MetaWorkflowRun created",
-    )
-    args = parser.parse_args()
-    auth_key = get_auth_key(args.auth_env)
-    post = not args.no_post
-    patch = not args.no_patch
-    create_meta_workflow_run(
-        args.input_item_identifier,
-        args.meta_workflow_identifier,
-        auth_key,
-        post=post,
-        patch=patch,
-    )
+@click.command()
+@click.help_option("--help", "-h")
+@click.option(
+    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
+)
+@click.option(
+    "-l",
+    "--length-required",
+    required=True,
+    type=int,
+    help="Requried length (can be obtained from FastQC output)",
+)
+@click.option(
+    "-e",
+    "--auth-env",
+    required=True,
+    type=str,
+    help="Name of environment in smaht-keys file",
+)
+def mwfr_illumina_alignment_cmd(fileset_accession, length_required, auth_env):
+    """Creates a MetaWorflowRun item in the portal for Illumina alignemnt of submitted files within a file set"""
+    smaht_key = get_auth_key(auth_env)
+    mwfr_illumina_alignment(fileset_accession, length_required, smaht_key)
 
 
-if __name__ == "__main__":
-    main()
+@click.command()
+@click.help_option("--help", "-h")
+@click.option(
+    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
+)
+@click.option(
+    "-e",
+    "--auth-env",
+    required=True,
+    type=str,
+    help="Name of environment in smaht-keys file",
+)
+def mwfr_pacbio_alignment_cmd(fileset_accession, auth_env):
+    """Creates a MetaWorflowRun item in the portal for Pacbio alignment of submitted files within a file set"""
+    smaht_key = get_auth_key(auth_env)
+    mwfr_pacbio_alignment(fileset_accession, smaht_key)
+
+
+@click.command()
+@click.help_option("--help", "-h")
+@click.option(
+    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
+)
+@click.option(
+    "-e",
+    "--auth-env",
+    required=True,
+    type=str,
+    help="Name of environment in smaht-keys file",
+)
+def mwfr_hic_alignment_cmd(fileset_accession, auth_env):
+    """Creates a MetaWorflowRun item in the portal for HIC alignment of submitted files within a file set"""
+    smaht_key = get_auth_key(auth_env)
+    mwfr_hic_alignment(fileset_accession, smaht_key)
+
+
+@click.command()
+@click.help_option("--help", "-h")
+@click.option(
+    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
+)
+@click.option(
+    "-e",
+    "--auth-env",
+    required=True,
+    type=str,
+    help="Name of environment in smaht-keys file",
+)
+def mwfr_ont_alignment_cmd(fileset_accession, auth_env):
+    """Creates a MetaWorflowRun item in the portal for ONT alignment of submitted files within a file set"""
+    smaht_key = get_auth_key(auth_env)
+    mwfr_ont_alignment(fileset_accession, smaht_key)
+
+
+
+@click.command()
+@click.help_option("--help", "-h")
+@click.option(
+    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
+)
+@click.option(
+    "-e",
+    "--auth-env",
+    required=True,
+    type=str,
+    help="Name of environment in smaht-keys file",
+)
+def mwfr_fastqc_cmd(fileset_accession, auth_env):
+    smaht_key = get_auth_key(auth_env)
+    mwfr_fastqc(fileset_accession, smaht_key)

--- a/magma_smaht/create_metawfr.py
+++ b/magma_smaht/create_metawfr.py
@@ -35,6 +35,15 @@ MWF_NAME_PACBIO = "PacBio_alignment_GRCh38"
 MWF_NAME_HIC = "Hi-C_alignment_GRCh38"
 MWF_NAME_FASTQC = "short_reads_FASTQ_quality_metrics"
 
+# Input argument names
+INPUT_FILES_R1_FASTQ_GZ = "input_files_r1_fastq_gz"
+INPUT_FILES_R2_FASTQ_GZ = "input_files_r2_fastq_gz"
+INPUT_FILES_BAM = "input_files_bam"
+INPUT_FILES_FASTQ_GZ = "input_files_fastq_gz"
+SAMPLE_NAME = "sample_name"
+LENGTH_REQUIRED = "length_required"
+LIBRARY_ID = "library_id"
+
 
 ################################################
 #   Functions
@@ -42,51 +51,46 @@ MWF_NAME_FASTQC = "short_reads_FASTQ_quality_metrics"
 
 
 def mwfr_illumina_alignment(fileset_accession, length_required, smaht_key):
-    """Creates a MetaWorflowRun item in the portal for Illumina alignemnt of submitted files within a file set"""
+    """Creates a MetaWorflowRun item in the portal for Illumina alignment of submitted files within a fileset"""
 
     mwf = get_latest_mwf(MWF_NAME_ILLUMINA, smaht_key)
     print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
 
     file_set = get_file_set(fileset_accession, smaht_key)
-    input_arg_1 = "input_files_r1_fastq_gz"
-    input_arg_2 = "input_files_r2_fastq_gz"
     mwfr_input = get_core_alignment_mwfr_input_from_readpairs(
-        file_set, input_arg_1, input_arg_2, smaht_key
+        file_set, INPUT_FILES_R1_FASTQ_GZ, INPUT_FILES_R2_FASTQ_GZ, smaht_key
     )
     # Illumina specific input
-    mwfr_input.append(get_mwfr_parameter_input_arg("length_required", length_required))
-    create_and_post_mwfr(mwf["uuid"], file_set, input_arg_1, mwfr_input, smaht_key)
+    mwfr_input.append(get_mwfr_parameter_input_arg(LENGTH_REQUIRED, length_required))
+    create_and_post_mwfr(mwf["uuid"], file_set, INPUT_FILES_R1_FASTQ_GZ, mwfr_input, smaht_key)
 
 
 def mwfr_pacbio_alignment(fileset_accession, smaht_key):
-    """Creates a MetaWorflowRun item in the portal for Pacbio alignment of submitted files within a file set"""
+    """Creates a MetaWorflowRun item in the portal for PacBio alignment of submitted files within a fileset"""
 
     mwf = get_latest_mwf(MWF_NAME_PACBIO, smaht_key)
     print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
 
     file_set = get_file_set(fileset_accession, smaht_key)
-    input_arg = "input_files_bam"
-    mwfr_input = get_core_alignment_mwfr_input(file_set, input_arg, smaht_key)
-    create_and_post_mwfr(mwf["uuid"], file_set, input_arg, mwfr_input, smaht_key)
+    mwfr_input = get_core_alignment_mwfr_input(file_set, INPUT_FILES_BAM, smaht_key)
+    create_and_post_mwfr(mwf["uuid"], file_set, INPUT_FILES_BAM, mwfr_input, smaht_key)
 
 
 def mwfr_hic_alignment(fileset_accession, smaht_key):
-    """Creates a MetaWorflowRun item in the portal for HIC alignment of submitted files within a file set"""
+    """Creates a MetaWorflowRun item in the portal for HI-C alignment of submitted files within a fileset"""
 
     mwf = get_latest_mwf(MWF_NAME_HIC, smaht_key)
     print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
 
     file_set = get_file_set(fileset_accession, smaht_key)
-    input_arg_1 = "input_files_r1_fastq_gz"
-    input_arg_2 = "input_files_r2_fastq_gz"
     mwfr_input = get_core_alignment_mwfr_input_from_readpairs(
-        file_set, input_arg_1, input_arg_2, smaht_key
+        file_set, INPUT_FILES_R1_FASTQ_GZ, INPUT_FILES_R2_FASTQ_GZ, smaht_key
     )
-    create_and_post_mwfr(mwf["uuid"], file_set, input_arg_1, mwfr_input, smaht_key)
+    create_and_post_mwfr(mwf["uuid"], file_set, INPUT_FILES_R1_FASTQ_GZ, mwfr_input, smaht_key)
 
 
 def mwfr_ont_alignment(fileset_accession, smaht_key):
-    """Creates a MetaWorflowRun item in the portal for HIC alignment of submitted files within a file set"""
+    """Creates a MetaWorflowRun item in the portal for ONT alignment of submitted files within a fileset"""
 
     mwf = get_latest_mwf(MWF_NAME_ONT, smaht_key)
     print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
@@ -108,15 +112,14 @@ def mwfr_ont_alignment(fileset_accession, smaht_key):
             {"file": file_fastq["derived_from"][0]["uuid"], "dimension": f"{dim}"}
         )
 
-    input_arg = "input_files_fastq_gz"
     mwfr_input = [
-        get_mwfr_file_input_arg(input_arg, fastqs),
-        get_mwfr_file_input_arg("input_files_bam", bams),
-        get_mwfr_parameter_input_arg("sample_name", sample["accession"]),
-        get_mwfr_parameter_input_arg("library_id", library["accession"]),
+        get_mwfr_file_input_arg(INPUT_FILES_FASTQ_GZ, fastqs),
+        get_mwfr_file_input_arg(INPUT_FILES_BAM, bams),
+        get_mwfr_parameter_input_arg(SAMPLE_NAME, sample["accession"]),
+        get_mwfr_parameter_input_arg(LIBRARY_ID, library["accession"]),
     ]
 
-    create_and_post_mwfr(mwf["uuid"], file_set, input_arg, mwfr_input, smaht_key)
+    create_and_post_mwfr(mwf["uuid"], file_set, INPUT_FILES_FASTQ_GZ, mwfr_input, smaht_key)
 
 
 def mwfr_fastqc(fileset_accession, smaht_key):
@@ -165,8 +168,8 @@ def get_core_alignment_mwfr_input_from_readpairs(
     mwfr_input = [
         get_mwfr_file_input_arg(file_input_arg_1, files_r1),
         get_mwfr_file_input_arg(file_input_arg_2, files_r2),
-        get_mwfr_parameter_input_arg("sample_name", sample["accession"]),
-        get_mwfr_parameter_input_arg("library_id", library["accession"]),
+        get_mwfr_parameter_input_arg(SAMPLE_NAME, sample["accession"]),
+        get_mwfr_parameter_input_arg(LIBRARY_ID, library["accession"]),
     ]
     return mwfr_input
 
@@ -186,8 +189,8 @@ def get_core_alignment_mwfr_input(file_set, file_input_arg, smaht_key):
 
     mwfr_input = [
         get_mwfr_file_input_arg(file_input_arg, files),
-        get_mwfr_parameter_input_arg("sample_name", sample["accession"]),
-        get_mwfr_parameter_input_arg("library_id", library["accession"]),
+        get_mwfr_parameter_input_arg(SAMPLE_NAME, sample["accession"]),
+        get_mwfr_parameter_input_arg(LIBRARY_ID, library["accession"]),
     ]
     return mwfr_input
 

--- a/magma_smaht/create_metawfr.py
+++ b/magma_smaht/create_metawfr.py
@@ -52,6 +52,8 @@ SEQUENCING_CENTER = "sequencing_center"
 CONSORTIA = "consortia"
 FILE_SETS = "file_sets"
 META_WORFLOW_RUN = "MetaWorkflowRun"
+ACCESSION = "accession"
+ALIASES = "aliases"
 
 
 ################################################
@@ -63,7 +65,7 @@ def mwfr_illumina_alignment(fileset_accession, length_required, smaht_key):
     """Creates a MetaWorflowRun item in the portal for Illumina alignment of submitted files within a fileset"""
 
     mwf = get_latest_mwf(MWF_NAME_ILLUMINA, smaht_key)
-    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
+    print(f"Using MetaWorkflow {mwf[ACCESSION]} ({mwf[ALIASES][0]})")
 
     file_set = get_file_set(fileset_accession, smaht_key)
     mwfr_input = get_core_alignment_mwfr_input_from_readpairs(
@@ -80,7 +82,7 @@ def mwfr_pacbio_alignment(fileset_accession, smaht_key):
     """Creates a MetaWorflowRun item in the portal for PacBio alignment of submitted files within a fileset"""
 
     mwf = get_latest_mwf(MWF_NAME_PACBIO, smaht_key)
-    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
+    print(f"Using MetaWorkflow {mwf[ACCESSION]} ({mwf[ALIASES][0]})")
 
     file_set = get_file_set(fileset_accession, smaht_key)
     mwfr_input = get_core_alignment_mwfr_input(file_set, INPUT_FILES_BAM, smaht_key)
@@ -91,7 +93,7 @@ def mwfr_hic_alignment(fileset_accession, smaht_key):
     """Creates a MetaWorflowRun item in the portal for HI-C alignment of submitted files within a fileset"""
 
     mwf = get_latest_mwf(MWF_NAME_HIC, smaht_key)
-    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
+    print(f"Using MetaWorkflow {mwf[ACCESSION]} ({mwf[ALIASES][0]})")
 
     file_set = get_file_set(fileset_accession, smaht_key)
     mwfr_input = get_core_alignment_mwfr_input_from_readpairs(
@@ -106,7 +108,7 @@ def mwfr_ont_alignment(fileset_accession, smaht_key):
     """Creates a MetaWorflowRun item in the portal for ONT alignment of submitted files within a fileset"""
 
     mwf = get_latest_mwf(MWF_NAME_ONT, smaht_key)
-    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
+    print(f"Using MetaWorkflow {mwf[ACCESSION]} ({mwf[ALIASES][0]})")
 
     # Collect Input
     file_set = get_file_set(fileset_accession, smaht_key)
@@ -129,8 +131,8 @@ def mwfr_ont_alignment(fileset_accession, smaht_key):
     mwfr_input = [
         get_mwfr_file_input_arg(INPUT_FILES_FASTQ_GZ, fastqs),
         get_mwfr_file_input_arg(INPUT_FILES_BAM, bams),
-        get_mwfr_parameter_input_arg(SAMPLE_NAME, sample["accession"]),
-        get_mwfr_parameter_input_arg(LIBRARY_ID, library["accession"]),
+        get_mwfr_parameter_input_arg(SAMPLE_NAME, sample[ACCESSION]),
+        get_mwfr_parameter_input_arg(LIBRARY_ID, library[ACCESSION]),
     ]
 
     create_and_post_mwfr(
@@ -142,7 +144,7 @@ def mwfr_fastqc(fileset_accession, smaht_key):
 
     file_set = get_file_set(fileset_accession, smaht_key)
     mwf = get_latest_mwf(MWF_NAME_FASTQC, smaht_key)
-    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
+    print(f"Using MetaWorkflow {mwf[ACCESSION]} ({mwf[ALIASES][0]})")
 
     # Get unaligned reads in the fileset that don't have already QC
     search_filter = f"?file_sets.uuid={file_set[UUID]}&type=UnalignedReads&file_format.display_title=fastq_gz&quality_metrics=No+value"
@@ -168,7 +170,7 @@ def get_common_fields(file_set):
     sequencing_centers = file_set[SUBMISSION_CENTERS]
     if len(sequencing_centers) != 1:
         raise Exception(
-            f"Exacted exactly one submission center for file set {file_set['accession']} expected but got {len(sequencing_centers)}"
+            f"Exacted exactly one submission center for file set {file_set[ACCESSION]} expected but got {len(sequencing_centers)}"
         )
 
     common_fields = {SEQUENCING_CENTER: sequencing_centers[0]}
@@ -199,8 +201,8 @@ def get_core_alignment_mwfr_input_from_readpairs(
     mwfr_input = [
         get_mwfr_file_input_arg(file_input_arg_1, files_r1),
         get_mwfr_file_input_arg(file_input_arg_2, files_r2),
-        get_mwfr_parameter_input_arg(SAMPLE_NAME, sample["accession"]),
-        get_mwfr_parameter_input_arg(LIBRARY_ID, library["accession"]),
+        get_mwfr_parameter_input_arg(SAMPLE_NAME, sample[ACCESSION]),
+        get_mwfr_parameter_input_arg(LIBRARY_ID, library[ACCESSION]),
     ]
     return mwfr_input
 
@@ -221,8 +223,8 @@ def get_core_alignment_mwfr_input(file_set, file_input_arg, smaht_key):
 
     mwfr_input = [
         get_mwfr_file_input_arg(file_input_arg, files),
-        get_mwfr_parameter_input_arg(SAMPLE_NAME, sample["accession"]),
-        get_mwfr_parameter_input_arg(LIBRARY_ID, library["accession"]),
+        get_mwfr_parameter_input_arg(SAMPLE_NAME, sample[ACCESSION]),
+        get_mwfr_parameter_input_arg(LIBRARY_ID, library[ACCESSION]),
     ]
     return mwfr_input
 
@@ -238,7 +240,7 @@ def create_and_post_mwfr(mwf_uuid, file_set, input_arg, mwfr_input, smaht_key):
     post_response = ff_utils.post_metadata(mwfr, META_WORFLOW_RUN, smaht_key)
     mwfr_accession = post_response["@graph"][0]["accession"]
     print(
-        f"Posted MetaWorkflowRun {mwfr_accession} for Fileset {file_set['accession']}."
+        f"Posted MetaWorkflowRun {mwfr_accession} for Fileset {file_set[ACCESSION]}."
     )
 
 

--- a/magma_smaht/create_metawfr.py
+++ b/magma_smaht/create_metawfr.py
@@ -27,7 +27,7 @@ from magma_smaht.utils import (
     get_mwfr_parameter_input_arg,
 )
 
-# MetaWorkflow names used to get latest version.
+# MetaWorkflow names are used to get the latest version.
 # We assume that they don't change!
 MWF_NAME_ILLUMINA = "Illumina_alignment_GRCh38"
 MWF_NAME_ONT = "ONT_alignment_GRCh38"
@@ -48,22 +48,14 @@ def mwfr_illumina_alignment(fileset_accession, length_required, smaht_key):
     print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
 
     file_set = get_file_set(fileset_accession, smaht_key)
-
-    mwfr_input = get_core_alignment_mwfr_input_from_readpairs(file_set, smaht_key)
+    input_arg_1 = "input_files_r1_fastq_gz"
+    input_arg_2 = "input_files_r2_fastq_gz"
+    mwfr_input = get_core_alignment_mwfr_input_from_readpairs(
+        file_set, input_arg_1, input_arg_2, smaht_key
+    )
     # Illumina specific input
     mwfr_input.append(get_mwfr_parameter_input_arg("length_required", length_required))
-
-    input_arg = "input_files_r1_fastq_gz"
-    mwfr = mwfr_from_input(mwf["uuid"], mwfr_input, input_arg, smaht_key)
-    mwfr["file_sets"] = [file_set["uuid"]]
-    # mwfr['final_status'] = 'stopped'
-
-    # print(mwfr)
-    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
-    mwfr_accession = post_response["@graph"][0]["accession"]
-    print(
-        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
-    )
+    create_and_post_mwfr(mwf["uuid"], file_set, input_arg_1, mwfr_input, smaht_key)
 
 
 def mwfr_pacbio_alignment(fileset_accession, smaht_key):
@@ -73,19 +65,9 @@ def mwfr_pacbio_alignment(fileset_accession, smaht_key):
     print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
 
     file_set = get_file_set(fileset_accession, smaht_key)
-
     input_arg = "input_files_bam"
     mwfr_input = get_core_alignment_mwfr_input(file_set, input_arg, smaht_key)
-
-    mwfr = mwfr_from_input(mwf["uuid"], mwfr_input, input_arg, smaht_key)
-    mwfr["file_sets"] = [file_set["uuid"]]
-    # mwfr['final_status'] = 'stopped'
-
-    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
-    mwfr_accession = post_response["@graph"][0]["accession"]
-    print(
-        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
-    )
+    create_and_post_mwfr(mwf["uuid"], file_set, input_arg, mwfr_input, smaht_key)
 
 
 def mwfr_hic_alignment(fileset_accession, smaht_key):
@@ -94,20 +76,13 @@ def mwfr_hic_alignment(fileset_accession, smaht_key):
     mwf = get_latest_mwf(MWF_NAME_HIC, smaht_key)
     print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
 
-    # Collect Input
     file_set = get_file_set(fileset_accession, smaht_key)
-    mwfr_input = get_core_alignment_mwfr_input_from_readpairs(file_set, smaht_key)
-
-    input_arg = "input_files_r1_fastq_gz"
-    mwfr = mwfr_from_input(mwf["uuid"], mwfr_input, input_arg, smaht_key)
-    mwfr["file_sets"] = [file_set["uuid"]]
-    mwfr['final_status'] = 'stopped'
-
-    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
-    mwfr_accession = post_response["@graph"][0]["accession"]
-    print(
-        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
+    input_arg_1 = "input_files_r1_fastq_gz"
+    input_arg_2 = "input_files_r2_fastq_gz"
+    mwfr_input = get_core_alignment_mwfr_input_from_readpairs(
+        file_set, input_arg_1, input_arg_2, smaht_key
     )
+    create_and_post_mwfr(mwf["uuid"], file_set, input_arg_1, mwfr_input, smaht_key)
 
 
 def mwfr_ont_alignment(fileset_accession, smaht_key):
@@ -122,16 +97,16 @@ def mwfr_ont_alignment(fileset_accession, smaht_key):
     sample = get_sample_from_library(library, smaht_key)
 
     # We are only retrieving the fastq files and get the bams from the derived_from property
-    search_filter = (
-        f"?type=UnalignedReads&file_format.display_title=fastq_gz&file_sets.uuid={file_set['uuid']}"
-    )
+    search_filter = f"?type=UnalignedReads&file_format.display_title=fastq_gz&file_sets.uuid={file_set['uuid']}"
     files_fastq = ff_utils.search_metadata(f"/search/{search_filter}", key=smaht_key)
 
     # Create files list for input args
     fastqs, bams = [], []
     for dim, file_fastq in enumerate(files_fastq):
         fastqs.append({"file": file_fastq["uuid"], "dimension": f"{dim}"})
-        bams.append({"file": file_fastq["derived_from"][0]["uuid"], "dimension": f"{dim}"})
+        bams.append(
+            {"file": file_fastq["derived_from"][0]["uuid"], "dimension": f"{dim}"}
+        )
 
     input_arg = "input_files_fastq_gz"
     mwfr_input = [
@@ -141,15 +116,7 @@ def mwfr_ont_alignment(fileset_accession, smaht_key):
         get_mwfr_parameter_input_arg("library_id", library["accession"]),
     ]
 
-    mwfr = mwfr_from_input(mwf["uuid"], mwfr_input, input_arg, smaht_key)
-    mwfr["file_sets"] = [file_set["uuid"]]
-    mwfr['final_status'] = 'stopped'
-
-    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
-    mwfr_accession = post_response["@graph"][0]["accession"]
-    print(
-        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
-    )
+    create_and_post_mwfr(mwf["uuid"], file_set, input_arg, mwfr_input, smaht_key)
 
 
 def mwfr_fastqc(fileset_accession, smaht_key):
@@ -158,8 +125,8 @@ def mwfr_fastqc(fileset_accession, smaht_key):
     mwf = get_latest_mwf(MWF_NAME_FASTQC, smaht_key)
     print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
 
-    # Get unaligned reads in fileset that don't have already QC
-    search_filter = f"?&file_sets.accession={fileset_accession}&type=UnalignedReads&file_format.display_title=fastq_gz&quality_metrics=No+value"
+    # Get unaligned reads in the fileset that don't have already QC
+    search_filter = f"?file_sets.uuid={file_set['uuid']}&type=UnalignedReads&file_format.display_title=fastq_gz&quality_metrics=No+value"
     files_to_run = ff_utils.search_metadata((f"search/{search_filter}"), key=smaht_key)
 
     if len(files_to_run) == 0:
@@ -172,18 +139,13 @@ def mwfr_fastqc(fileset_accession, smaht_key):
 
     input_arg = "input_files_fastq_gz"
     mwfr_input = [get_mwfr_file_input_arg(input_arg, files_input)]
-    mwfr = mwfr_from_input(mwf["uuid"], mwfr_input, input_arg, smaht_key)
-    mwfr["file_sets"] = [file_set["uuid"]]
-    # mwfr['final_status'] = 'stopped'
 
-    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
-    mwfr_accession = post_response["@graph"][0]["accession"]
-    print(
-        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
-    )
+    create_and_post_mwfr(mwf["uuid"], file_set, input_arg, mwfr_input, smaht_key)
 
 
-def get_core_alignment_mwfr_input_from_readpairs(file_set, smaht_key):
+def get_core_alignment_mwfr_input_from_readpairs(
+    file_set, file_input_arg_1, file_input_arg_2, smaht_key
+):
 
     library = get_library_from_file_set(file_set, smaht_key)
     sample = get_sample_from_library(library, smaht_key)
@@ -201,15 +163,15 @@ def get_core_alignment_mwfr_input_from_readpairs(file_set, smaht_key):
         files_r1.append({"file": file_r2["paired_with"]["uuid"], "dimension": f"{dim}"})
 
     mwfr_input = [
-        get_mwfr_file_input_arg("input_files_r1_fastq_gz", files_r1),
-        get_mwfr_file_input_arg("input_files_r2_fastq_gz", files_r2),
+        get_mwfr_file_input_arg(file_input_arg_1, files_r1),
+        get_mwfr_file_input_arg(file_input_arg_2, files_r2),
         get_mwfr_parameter_input_arg("sample_name", sample["accession"]),
         get_mwfr_parameter_input_arg("library_id", library["accession"]),
     ]
     return mwfr_input
 
 
-def get_core_alignment_mwfr_input(file_set, input_arg, smaht_key):
+def get_core_alignment_mwfr_input(file_set, file_input_arg, smaht_key):
 
     library = get_library_from_file_set(file_set, smaht_key)
     sample = get_sample_from_library(library, smaht_key)
@@ -223,11 +185,24 @@ def get_core_alignment_mwfr_input(file_set, input_arg, smaht_key):
         files.append({"file": file["uuid"], "dimension": f"{dim}"})
 
     mwfr_input = [
-        get_mwfr_file_input_arg(input_arg, files),
+        get_mwfr_file_input_arg(file_input_arg, files),
         get_mwfr_parameter_input_arg("sample_name", sample["accession"]),
         get_mwfr_parameter_input_arg("library_id", library["accession"]),
     ]
     return mwfr_input
+
+
+def create_and_post_mwfr(mwf_uuid, file_set, input_arg, mwfr_input, smaht_key):
+
+    mwfr = mwfr_from_input(mwf_uuid, mwfr_input, input_arg, smaht_key)
+    mwfr["file_sets"] = [file_set["uuid"]]
+    # mwfr['final_status'] = 'stopped'
+    # print(mwfr)
+    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
+    mwfr_accession = post_response["@graph"][0]["accession"]
+    print(
+        f"Posted MetaWorkflowRun {mwfr_accession} for Fileset {file_set['accession']}."
+    )
 
 
 def filter_list_of_dicts(list_of_dics, property_target, target):

--- a/magma_smaht/create_metawfr.py
+++ b/magma_smaht/create_metawfr.py
@@ -9,7 +9,7 @@
 ################################################
 #   Libraries
 ################################################
-import click
+
 import json, uuid
 from dcicutils import ff_utils
 import pprint
@@ -25,7 +25,6 @@ from magma_smaht.utils import (
     get_sample_from_library,
     get_mwfr_file_input_arg,
     get_mwfr_parameter_input_arg,
-    get_auth_key,
 )
 
 # MetaWorkflow names used to get latest version.
@@ -42,36 +41,150 @@ MWF_NAME_FASTQC = "short_reads_FASTQ_quality_metrics"
 ################################################
 
 
-@click.command()
-@click.help_option("--help", "-h")
-@click.option(
-    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
-)
-@click.option(
-    "-l",
-    "--length-required",
-    required=True,
-    type=int,
-    help="Requried length (can be obtained from FastQC output)",
-)
-@click.option(
-    "-e",
-    "--auth-env",
-    required=True,
-    type=str,
-    help="Name of environment in smaht-keys file",
-)
-def mwfr_illumina_alignment(fileset_accession, length_required, auth_env):
+def mwfr_illumina_alignment(fileset_accession, length_required, smaht_key):
     """Creates a MetaWorflowRun item in the portal for Illumina alignemnt of submitted files within a file set"""
 
-    smaht_key = get_auth_key(auth_env)
-
     mwf = get_latest_mwf(MWF_NAME_ILLUMINA, smaht_key)
-    mwf_uuid = mwf["uuid"]
+    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
+
+    file_set = get_file_set(fileset_accession, smaht_key)
+
+    mwfr_input = get_core_alignment_mwfr_input_from_readpairs(file_set, smaht_key)
+    # Illumina specific input
+    mwfr_input.append(get_mwfr_parameter_input_arg("length_required", length_required))
+
+    input_arg = "input_files_r1_fastq_gz"
+    mwfr = mwfr_from_input(mwf["uuid"], mwfr_input, input_arg, smaht_key)
+    mwfr["file_sets"] = [file_set["uuid"]]
+    # mwfr['final_status'] = 'stopped'
+
+    # print(mwfr)
+    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
+    mwfr_accession = post_response["@graph"][0]["accession"]
+    print(
+        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
+    )
+
+
+def mwfr_pacbio_alignment(fileset_accession, smaht_key):
+    """Creates a MetaWorflowRun item in the portal for Pacbio alignment of submitted files within a file set"""
+
+    mwf = get_latest_mwf(MWF_NAME_PACBIO, smaht_key)
+    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
+
+    file_set = get_file_set(fileset_accession, smaht_key)
+
+    input_arg = "input_files_bam"
+    mwfr_input = get_core_alignment_mwfr_input(file_set, input_arg, smaht_key)
+
+    mwfr = mwfr_from_input(mwf["uuid"], mwfr_input, input_arg, smaht_key)
+    mwfr["file_sets"] = [file_set["uuid"]]
+    # mwfr['final_status'] = 'stopped'
+
+    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
+    mwfr_accession = post_response["@graph"][0]["accession"]
+    print(
+        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
+    )
+
+
+def mwfr_hic_alignment(fileset_accession, smaht_key):
+    """Creates a MetaWorflowRun item in the portal for HIC alignment of submitted files within a file set"""
+
+    mwf = get_latest_mwf(MWF_NAME_HIC, smaht_key)
     print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
 
     # Collect Input
     file_set = get_file_set(fileset_accession, smaht_key)
+    mwfr_input = get_core_alignment_mwfr_input_from_readpairs(file_set, smaht_key)
+
+    input_arg = "input_files_r1_fastq_gz"
+    mwfr = mwfr_from_input(mwf["uuid"], mwfr_input, input_arg, smaht_key)
+    mwfr["file_sets"] = [file_set["uuid"]]
+    mwfr['final_status'] = 'stopped'
+
+    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
+    mwfr_accession = post_response["@graph"][0]["accession"]
+    print(
+        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
+    )
+
+
+def mwfr_ont_alignment(fileset_accession, smaht_key):
+    """Creates a MetaWorflowRun item in the portal for HIC alignment of submitted files within a file set"""
+
+    mwf = get_latest_mwf(MWF_NAME_ONT, smaht_key)
+    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
+
+    # Collect Input
+    file_set = get_file_set(fileset_accession, smaht_key)
+    library = get_library_from_file_set(file_set, smaht_key)
+    sample = get_sample_from_library(library, smaht_key)
+
+    # We are only retrieving the fastq files and get the bams from the derived_from property
+    search_filter = (
+        f"?type=UnalignedReads&file_format.display_title=fastq_gz&file_sets.uuid={file_set['uuid']}"
+    )
+    files_fastq = ff_utils.search_metadata(f"/search/{search_filter}", key=smaht_key)
+
+    # Create files list for input args
+    fastqs, bams = [], []
+    for dim, file_fastq in enumerate(files_fastq):
+        fastqs.append({"file": file_fastq["uuid"], "dimension": f"{dim}"})
+        bams.append({"file": file_fastq["derived_from"][0]["uuid"], "dimension": f"{dim}"})
+
+    input_arg = "input_files_fastq_gz"
+    mwfr_input = [
+        get_mwfr_file_input_arg(input_arg, fastqs),
+        get_mwfr_file_input_arg("input_files_bam", bams),
+        get_mwfr_parameter_input_arg("sample_name", sample["accession"]),
+        get_mwfr_parameter_input_arg("library_id", library["accession"]),
+    ]
+
+    mwfr = mwfr_from_input(mwf["uuid"], mwfr_input, input_arg, smaht_key)
+    mwfr["file_sets"] = [file_set["uuid"]]
+    mwfr['final_status'] = 'stopped'
+
+    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
+    mwfr_accession = post_response["@graph"][0]["accession"]
+    print(
+        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
+    )
+
+
+def mwfr_fastqc(fileset_accession, smaht_key):
+
+    file_set = get_file_set(fileset_accession, smaht_key)
+    mwf = get_latest_mwf(MWF_NAME_FASTQC, smaht_key)
+    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
+
+    # Get unaligned reads in fileset that don't have already QC
+    search_filter = f"?&file_sets.accession={fileset_accession}&type=UnalignedReads&file_format.display_title=fastq_gz&quality_metrics=No+value"
+    files_to_run = ff_utils.search_metadata((f"search/{search_filter}"), key=smaht_key)
+
+    if len(files_to_run) == 0:
+        print(f"No files to run for search {search_filter}")
+        return
+
+    files_input = []
+    for dim, file in enumerate(files_to_run):
+        files_input.append({"file": file["uuid"], "dimension": f"{dim}"})
+
+    input_arg = "input_files_fastq_gz"
+    mwfr_input = [get_mwfr_file_input_arg(input_arg, files_input)]
+    mwfr = mwfr_from_input(mwf["uuid"], mwfr_input, input_arg, smaht_key)
+    mwfr["file_sets"] = [file_set["uuid"]]
+    # mwfr['final_status'] = 'stopped'
+
+    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
+    mwfr_accession = post_response["@graph"][0]["accession"]
+    print(
+        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
+    )
+
+
+def get_core_alignment_mwfr_input_from_readpairs(file_set, smaht_key):
+
     library = get_library_from_file_set(file_set, smaht_key)
     sample = get_sample_from_library(library, smaht_key)
 
@@ -92,48 +205,12 @@ def mwfr_illumina_alignment(fileset_accession, length_required, auth_env):
         get_mwfr_file_input_arg("input_files_r2_fastq_gz", files_r2),
         get_mwfr_parameter_input_arg("sample_name", sample["accession"]),
         get_mwfr_parameter_input_arg("library_id", library["accession"]),
-        get_mwfr_parameter_input_arg("length_required", length_required),
     ]
-
-    input_arg = "input_files_r1_fastq_gz"
-    # pp.pprint(mwfr_input)
-    mwfr = mwfr_from_input(mwf_uuid, mwfr_input, input_arg, smaht_key)
-    # mwfr['final_status'] = 'stopped'
-
-    # Associate MWFR with file set
-    mwfr["file_sets"] = [file_set["uuid"]]
-
-    # print(mwfr)
-    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
-    mwfr_accession = post_response["@graph"][0]["accession"]
-    print(
-        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
-    )
+    return mwfr_input
 
 
-@click.command()
-@click.help_option("--help", "-h")
-@click.option(
-    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
-)
-@click.option(
-    "-e",
-    "--auth-env",
-    required=True,
-    type=str,
-    help="Name of environment in smaht-keys file",
-)
-def mwfr_pacbio_alignment(fileset_accession, auth_env):
-    """Creates a MetaWorflowRun item in the portal for Pacbio alignment of submitted files within a file set"""
+def get_core_alignment_mwfr_input(file_set, input_arg, smaht_key):
 
-    smaht_key = get_auth_key(auth_env)
-
-    mwf = get_latest_mwf(MWF_NAME_PACBIO, smaht_key)
-    mwf_uuid = mwf["uuid"]
-    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
-
-    # Collect Input
-    file_set = get_file_set(fileset_accession, smaht_key)
     library = get_library_from_file_set(file_set, smaht_key)
     sample = get_sample_from_library(library, smaht_key)
 
@@ -146,73 +223,10 @@ def mwfr_pacbio_alignment(fileset_accession, auth_env):
         files.append({"file": file["uuid"], "dimension": f"{dim}"})
 
     mwfr_input = [
-        get_mwfr_file_input_arg("input_files_bam", files),
+        get_mwfr_file_input_arg(input_arg, files),
         get_mwfr_parameter_input_arg("sample_name", sample["accession"]),
         get_mwfr_parameter_input_arg("library_id", library["accession"]),
     ]
-
-    input_arg = "input_files_bam"
-    mwfr = mwfr_from_input(mwf_uuid, mwfr_input, input_arg, smaht_key)
-    mwfr['final_status'] = 'stopped'
-
-    # Associate MWFR with file set
-    mwfr["file_sets"] = [file_set["uuid"]]
-
-    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
-    mwfr_accession = post_response["@graph"][0]["accession"]
-    print(
-        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
-    )
-
-
-@click.command()
-@click.help_option("--help", "-h")
-@click.option(
-    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
-)
-@click.option(
-    "-e",
-    "--auth-env",
-    required=True,
-    type=str,
-    help="Name of environment in smaht-keys file",
-)
-def mwfr_fastqc(fileset_accession, auth_env):
-
-    smaht_key = get_auth_key(auth_env)
-
-    file_set = get_file_set(fileset_accession, smaht_key)
-    mwf = get_latest_mwf(MWF_NAME_FASTQC, smaht_key)
-    mwf_uuid = mwf["uuid"]
-    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
-
-    # Get unaligned reads in fileset that don't have already QC
-    search_filter = f"?&file_sets.accession={fileset_accession}&type=UnalignedReads&file_format.display_title=fastq_gz&quality_metrics=No+value"
-    files_to_run = ff_utils.search_metadata((f"search/{search_filter}"), key=smaht_key)
-
-    if len(files_to_run) == 0:
-        print(f"No files to run for search {search_filter}")
-        return
-
-    files_to_run = [file["uuid"] for file in files_to_run]
-
-    files_input = []
-    for dim, file in enumerate(files_to_run):
-        files_input.append({"file": file["uuid"], "dimension": f"{dim}"})
-
-    input_arg = "input_files_fastq_gz"
-    mwfr_input = [get_mwfr_file_input_arg(input_arg, files_input)]
-    mwfr = mwfr_from_input(mwf_uuid, mwfr_input, input_arg, smaht_key)
-    # mwfr['final_status'] = 'stopped'
-
-    # Associate MWFR with file set
-    mwfr["file_sets"] = [file_set["uuid"]]
-
-    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
-    mwfr_accession = post_response["@graph"][0]["accession"]
-    print(
-        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
-    )
 
 
 def filter_list_of_dicts(list_of_dics, property_target, target):

--- a/magma_smaht/create_metawfr.py
+++ b/magma_smaht/create_metawfr.py
@@ -9,15 +9,152 @@
 ################################################
 #   Libraries
 ################################################
+import click
 import json, uuid
 from dcicutils import ff_utils
 
 # magma
 from magma_smaht.metawfl import MetaWorkflow
+from magma_smaht.utils import get_latest_mwf, get_library_from_file_set, get_sample_from_library, get_mwfr_file_input_arg, get_mwfr_parameter_input_arg, get_auth_key
+
+# MetaWorkflow names used to get latest version. 
+# We assume that they don't change!
+MWF_NAME_ILLUMINA = "Illumina_alignment_GRCh38"
+MWF_NAME_ONT = "ONT_alignment_GRCh38"
+MWF_NAME_PACBIO = "PacBio_alignment_GRCh38"
+MWF_NAME_HIC = "Hi-C_alignment_GRCh38"
+MWF_NAME_FASTQC = "short_reads_FASTQ_quality_metrics"
+
 
 ################################################
 #   Functions
 ################################################
+
+@click.command()
+@click.help_option("--help", "-h")
+@click.option(
+    "-f", 
+    "--fileset-accession", 
+    required=True, 
+    type=str, 
+    help="Fileset accession"
+)
+@click.option(
+    "-l", 
+    "--length-required", 
+    required=True, 
+    type=int, 
+    help="Requried length (can be obtained from FastQC output)"
+)
+@click.option(
+    "-e", 
+    "--auth-env", 
+    required=True, 
+    type=str, 
+    help="Requried length (can be obtained from FastQC output)"
+)
+def mwfr_illumina_alignment(fileset_accession, length_required, auth_env):
+    """Creates a MetaWorflowRun item in the portal for Illumina alignemnt of submitted files within a file set
+    """
+
+    smaht_key = get_auth_key(auth_env)
+
+    mwf = get_latest_mwf(MWF_NAME_ILLUMINA, smaht_key)
+    mwf_uuid = mwf["uuid"]
+    print(f"Using MetaWorkflow {mwf["accession"]} ({mwf["aliases"][0]})")
+
+    # Collect Input
+    library = get_library_from_file_set(
+        fileset_accession, smaht_key
+    )
+    library_accession = library["accession"]
+    sample = get_sample_from_library(library, smaht_key)
+    sample_accession = sample["accession"]
+
+    # We are only retrieving the R2 reads and get the R1 read from the paired_with property
+    search_filter = (
+        f"?type=UnalignedReads&read_pair_number=R2&file_sets.accession={fileset_accession}"
+    )
+    reads_r2 = ff_utils.search_metadata(f"/search/{search_filter}", key=smaht_key)
+
+    # Create files list for input args
+    files_r1, files_r2 = [], []
+    for dim, file_r2 in enumerate(reads_r2):
+        files_r2.append({"file": file_r2["uuid"], "dimension": f"{dim}"})
+        files_r1.append(
+            {"file": reads_r2["paired_with"]["uuid"], "dimension": f"{dim}"}
+        )
+
+    mwfr_input = [
+        get_mwfr_file_input_arg("input_files_r1_fastq_gz", files_r1),
+        get_mwfr_file_input_arg("input_files_r2_fastq_gz", files_r2),
+        get_mwfr_parameter_input_arg("sample_name", sample_accession),
+        get_mwfr_parameter_input_arg("library_id", library_accession),
+        get_mwfr_parameter_input_arg("length_required", length_required),
+    ]
+
+    input_arg = "input_files_r1_fastq_gz"
+    mwfr = mwfr_from_input(mwf_uuid, mwfr_input, input_arg, smaht_key)
+    #mwfr['final_status'] = 'stopped'
+    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
+    mwfr_accession = post_response["@graph"][0]["accession"]
+    print(f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}.")
+
+
+@click.command()
+@click.help_option("--help", "-h")
+@click.option(
+    "-f", 
+    "--fileset-accession", 
+    required=True, 
+    type=str, 
+    help="Fileset accession"
+)
+@click.option(
+    "-e", 
+    "--auth-env", 
+    required=True, 
+    type=str, 
+    help="Requried length (can be obtained from FastQC output)"
+)
+def mwfr_fastqc(fileset_accession, auth_env):
+
+    smaht_key = get_auth_key(auth_env)
+
+    mwf = get_latest_mwf(MWF_NAME_FASTQC, smaht_key)
+    mwf_uuid = mwf["uuid"]
+    print(f"Using MetaWorkflow {mwf["accession"]} ({mwf["aliases"][0]})")
+
+    # Get unaligned reads in fileset that don't have already QC
+    search_filter = f"?&file_sets.accession={fileset_accession}&type=UnalignedReads&file_format.display_title=fastq_gz&quality_metrics=No+value"
+    files_to_run = ff_utils.search_metadata(
+    (
+        f"search/{search_filter}"
+    ),
+    key=smaht_key)
+
+    if len(files_to_run) == 0:
+        print(f"No files to run for search {search_filter}")
+        return
+    
+    files_to_run = [files_to_run["uuid"] for file in files_to_run]
+
+    files_input = []
+    for dim, file in enumerate(files_to_run):
+        files_input.append({"file": file["uuid"], "dimension": f"{dim}"})
+
+    input_arg = "input_files_fastq_gz"
+    mwfr_input = [get_mwfr_file_input_arg(input_arg, files_input)]
+    mwfr = mwfr_from_input(mwf_uuid, mwfr_input, input_arg, smaht_key)
+    #mwfr['final_status'] = 'stopped'
+    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
+    mwfr_accession = post_response["@graph"][0]["accession"]
+    print(f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}.")
+
+
+def filter_list_of_dicts(list_of_dics, property_target, target):
+    return [w for w in list_of_dics if w[property_target] == target]
+
 
 def mwfr_from_input(
     metawf_uuid,

--- a/magma_smaht/create_metawfr.py
+++ b/magma_smaht/create_metawfr.py
@@ -12,12 +12,23 @@
 import click
 import json, uuid
 from dcicutils import ff_utils
+import pprint
+
+pp = pprint.PrettyPrinter(indent=2)
 
 # magma
 from magma_smaht.metawfl import MetaWorkflow
-from magma_smaht.utils import get_latest_mwf, get_library_from_file_set, get_sample_from_library, get_mwfr_file_input_arg, get_mwfr_parameter_input_arg, get_auth_key
+from magma_smaht.utils import (
+    get_latest_mwf,
+    get_file_set,
+    get_library_from_file_set,
+    get_sample_from_library,
+    get_mwfr_file_input_arg,
+    get_mwfr_parameter_input_arg,
+    get_auth_key,
+)
 
-# MetaWorkflow names used to get latest version. 
+# MetaWorkflow names used to get latest version.
 # We assume that they don't change!
 MWF_NAME_ILLUMINA = "Illumina_alignment_GRCh38"
 MWF_NAME_ONT = "ONT_alignment_GRCh38"
@@ -30,50 +41,43 @@ MWF_NAME_FASTQC = "short_reads_FASTQ_quality_metrics"
 #   Functions
 ################################################
 
+
 @click.command()
 @click.help_option("--help", "-h")
 @click.option(
-    "-f", 
-    "--fileset-accession", 
-    required=True, 
-    type=str, 
-    help="Fileset accession"
+    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
 )
 @click.option(
-    "-l", 
-    "--length-required", 
-    required=True, 
-    type=int, 
-    help="Requried length (can be obtained from FastQC output)"
+    "-l",
+    "--length-required",
+    required=True,
+    type=int,
+    help="Requried length (can be obtained from FastQC output)",
 )
 @click.option(
-    "-e", 
-    "--auth-env", 
-    required=True, 
-    type=str, 
-    help="Requried length (can be obtained from FastQC output)"
+    "-e",
+    "--auth-env",
+    required=True,
+    type=str,
+    help="Name of environment in smaht-keys file",
 )
 def mwfr_illumina_alignment(fileset_accession, length_required, auth_env):
-    """Creates a MetaWorflowRun item in the portal for Illumina alignemnt of submitted files within a file set
-    """
+    """Creates a MetaWorflowRun item in the portal for Illumina alignemnt of submitted files within a file set"""
 
     smaht_key = get_auth_key(auth_env)
 
     mwf = get_latest_mwf(MWF_NAME_ILLUMINA, smaht_key)
     mwf_uuid = mwf["uuid"]
-    print(f"Using MetaWorkflow {mwf["accession"]} ({mwf["aliases"][0]})")
+    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
 
     # Collect Input
-    library = get_library_from_file_set(
-        fileset_accession, smaht_key
-    )
-    library_accession = library["accession"]
+    file_set = get_file_set(fileset_accession, smaht_key)
+    library = get_library_from_file_set(file_set, smaht_key)
     sample = get_sample_from_library(library, smaht_key)
-    sample_accession = sample["accession"]
 
     # We are only retrieving the R2 reads and get the R1 read from the paired_with property
     search_filter = (
-        f"?type=UnalignedReads&read_pair_number=R2&file_sets.accession={fileset_accession}"
+        f"?type=UnalignedReads&read_pair_number=R2&file_sets.uuid={file_set['uuid']}"
     )
     reads_r2 = ff_utils.search_metadata(f"/search/{search_filter}", key=smaht_key)
 
@@ -81,63 +85,116 @@ def mwfr_illumina_alignment(fileset_accession, length_required, auth_env):
     files_r1, files_r2 = [], []
     for dim, file_r2 in enumerate(reads_r2):
         files_r2.append({"file": file_r2["uuid"], "dimension": f"{dim}"})
-        files_r1.append(
-            {"file": reads_r2["paired_with"]["uuid"], "dimension": f"{dim}"}
-        )
+        files_r1.append({"file": file_r2["paired_with"]["uuid"], "dimension": f"{dim}"})
 
     mwfr_input = [
         get_mwfr_file_input_arg("input_files_r1_fastq_gz", files_r1),
         get_mwfr_file_input_arg("input_files_r2_fastq_gz", files_r2),
-        get_mwfr_parameter_input_arg("sample_name", sample_accession),
-        get_mwfr_parameter_input_arg("library_id", library_accession),
+        get_mwfr_parameter_input_arg("sample_name", sample["accession"]),
+        get_mwfr_parameter_input_arg("library_id", library["accession"]),
         get_mwfr_parameter_input_arg("length_required", length_required),
     ]
 
     input_arg = "input_files_r1_fastq_gz"
+    # pp.pprint(mwfr_input)
     mwfr = mwfr_from_input(mwf_uuid, mwfr_input, input_arg, smaht_key)
-    #mwfr['final_status'] = 'stopped'
+    # mwfr['final_status'] = 'stopped'
+
+    # Associate MWFR with file set
+    mwfr["file_sets"] = [file_set["uuid"]]
+
+    # print(mwfr)
     post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
     mwfr_accession = post_response["@graph"][0]["accession"]
-    print(f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}.")
+    print(
+        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
+    )
 
 
 @click.command()
 @click.help_option("--help", "-h")
 @click.option(
-    "-f", 
-    "--fileset-accession", 
-    required=True, 
-    type=str, 
-    help="Fileset accession"
+    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
 )
 @click.option(
-    "-e", 
-    "--auth-env", 
-    required=True, 
-    type=str, 
-    help="Requried length (can be obtained from FastQC output)"
+    "-e",
+    "--auth-env",
+    required=True,
+    type=str,
+    help="Name of environment in smaht-keys file",
+)
+def mwfr_pacbio_alignment(fileset_accession, auth_env):
+    """Creates a MetaWorflowRun item in the portal for Pacbio alignment of submitted files within a file set"""
+
+    smaht_key = get_auth_key(auth_env)
+
+    mwf = get_latest_mwf(MWF_NAME_PACBIO, smaht_key)
+    mwf_uuid = mwf["uuid"]
+    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
+
+    # Collect Input
+    file_set = get_file_set(fileset_accession, smaht_key)
+    library = get_library_from_file_set(file_set, smaht_key)
+    sample = get_sample_from_library(library, smaht_key)
+
+    search_filter = f"?type=UnalignedReads&file_sets.uuid={file_set['uuid']}"
+    search_result = ff_utils.search_metadata(f"/search/{search_filter}", key=smaht_key)
+
+    # Create files list for input args
+    files = []
+    for dim, file in enumerate(search_result):
+        files.append({"file": file["uuid"], "dimension": f"{dim}"})
+
+    mwfr_input = [
+        get_mwfr_file_input_arg("input_files_bam", files),
+        get_mwfr_parameter_input_arg("sample_name", sample["accession"]),
+        get_mwfr_parameter_input_arg("library_id", library["accession"]),
+    ]
+
+    input_arg = "input_files_bam"
+    mwfr = mwfr_from_input(mwf_uuid, mwfr_input, input_arg, smaht_key)
+    mwfr['final_status'] = 'stopped'
+
+    # Associate MWFR with file set
+    mwfr["file_sets"] = [file_set["uuid"]]
+
+    post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
+    mwfr_accession = post_response["@graph"][0]["accession"]
+    print(
+        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
+    )
+
+
+@click.command()
+@click.help_option("--help", "-h")
+@click.option(
+    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
+)
+@click.option(
+    "-e",
+    "--auth-env",
+    required=True,
+    type=str,
+    help="Name of environment in smaht-keys file",
 )
 def mwfr_fastqc(fileset_accession, auth_env):
 
     smaht_key = get_auth_key(auth_env)
 
+    file_set = get_file_set(fileset_accession, smaht_key)
     mwf = get_latest_mwf(MWF_NAME_FASTQC, smaht_key)
     mwf_uuid = mwf["uuid"]
-    print(f"Using MetaWorkflow {mwf["accession"]} ({mwf["aliases"][0]})")
+    print(f"Using MetaWorkflow {mwf['accession']} ({mwf['aliases'][0]})")
 
     # Get unaligned reads in fileset that don't have already QC
     search_filter = f"?&file_sets.accession={fileset_accession}&type=UnalignedReads&file_format.display_title=fastq_gz&quality_metrics=No+value"
-    files_to_run = ff_utils.search_metadata(
-    (
-        f"search/{search_filter}"
-    ),
-    key=smaht_key)
+    files_to_run = ff_utils.search_metadata((f"search/{search_filter}"), key=smaht_key)
 
     if len(files_to_run) == 0:
         print(f"No files to run for search {search_filter}")
         return
-    
-    files_to_run = [files_to_run["uuid"] for file in files_to_run]
+
+    files_to_run = [file["uuid"] for file in files_to_run]
 
     files_input = []
     for dim, file in enumerate(files_to_run):
@@ -146,10 +203,16 @@ def mwfr_fastqc(fileset_accession, auth_env):
     input_arg = "input_files_fastq_gz"
     mwfr_input = [get_mwfr_file_input_arg(input_arg, files_input)]
     mwfr = mwfr_from_input(mwf_uuid, mwfr_input, input_arg, smaht_key)
-    #mwfr['final_status'] = 'stopped'
+    # mwfr['final_status'] = 'stopped'
+
+    # Associate MWFR with file set
+    mwfr["file_sets"] = [file_set["uuid"]]
+
     post_response = ff_utils.post_metadata(mwfr, "MetaWorkflowRun", smaht_key)
     mwfr_accession = post_response["@graph"][0]["accession"]
-    print(f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}.")
+    print(
+        f"Posted alignment MetaWorkflowRun {mwfr_accession} for Fileset {fileset_accession}."
+    )
 
 
 def filter_list_of_dicts(list_of_dics, property_target, target):

--- a/magma_smaht/create_metawfr.py
+++ b/magma_smaht/create_metawfr.py
@@ -227,6 +227,7 @@ def get_core_alignment_mwfr_input(file_set, input_arg, smaht_key):
         get_mwfr_parameter_input_arg("sample_name", sample["accession"]),
         get_mwfr_parameter_input_arg("library_id", library["accession"]),
     ]
+    return mwfr_input
 
 
 def filter_list_of_dicts(list_of_dics, property_target, target):

--- a/magma_smaht/utils.py
+++ b/magma_smaht/utils.py
@@ -138,7 +138,7 @@ def keep_last_item(items: Sequence) -> Sequence:
 
 
 def get_file_set(fileset_accession, smaht_key):
-    """Get the file set from its accession
+    """Get the fileset from its accession
 
     Args:
         fileset_accession (str): fileset accession
@@ -160,7 +160,7 @@ def get_library_from_file_set(file_set, smaht_key):
         smaht_key (dict): SMaHT key
 
     Raises:
-        Exception: Raises an exception when there are multiple libraried associated
+        Exception: Raises an exception when there are multiple libraries associated
 
     Returns:
         dict: Library item from portal
@@ -198,7 +198,7 @@ def get_sample_from_library(library, smaht_key):
 
 
 def get_latest_mwf(mwf_name, smaht_key):
-    """Gets the latest version of the MWF with name `mwf_name`
+    """Get the latest version of the MWF with name `mwf_name`
 
     Args:
         mwf_name (string): Name of the MWF

--- a/magma_smaht/utils.py
+++ b/magma_smaht/utils.py
@@ -79,7 +79,7 @@ def chunk_ids(ids):
     result = []
     chunk_size = 5
     for idx in range(0, len(ids), chunk_size):
-        result.append(ids[idx : idx + chunk_size])
+        result.append(ids[idx: idx + chunk_size])
     return result
 
 
@@ -137,6 +137,21 @@ def keep_last_item(items: Sequence) -> Sequence:
     return result
 
 
+def get_file_set(fileset_accession, smaht_key):
+    """Get the file set from its accession
+
+    Args:
+        fileset_accession (str): fileset accession
+        smaht_key (dict): SMaHT key
+
+    Returns:
+        dict: Fileset item from portal
+    """
+    return ff_utils.get_metadata(
+        fileset_accession, add_on="frame=raw&datastore=database", key=smaht_key
+    )
+
+
 def get_library_from_file_set(file_set, smaht_key):
     """Get the library that is associated with a fileset
 
@@ -157,7 +172,6 @@ def get_library_from_file_set(file_set, smaht_key):
         file_set["libraries"][0], add_on="frame=raw&datastore=database", key=smaht_key
     )
     return library
-
 
 def get_sample_from_library(library, smaht_key):
     """Get the sample that is associated with a library
@@ -195,19 +209,17 @@ def get_latest_mwf(mwf_name, smaht_key):
     """
     query = f"/search/?type=MetaWorkflow&name={mwf_name}"
     search_results = ff_utils.search_metadata(query, key=smaht_key)
-
+    
     if len(search_results) == 0:
         return None
-
+    
     latest_result = search_results[0]
     if len(search_results) == 1:
         return latest_result
-
+    
     # There are multiple MWFs. Get the latest version
     for search_result in search_results:
-        if version.parse(latest_result["version"]) < version.parse(
-            search_result["version"]
-        ):
+        if version.parse(latest_result["version"]) < version.parse(search_result["version"]):
             latest_result = search_result
     return latest_result
 

--- a/magma_smaht/utils.py
+++ b/magma_smaht/utils.py
@@ -12,6 +12,7 @@
 import json
 from pathlib import Path
 from typing import Any, Dict, Sequence
+from packaging import version
 
 from dcicutils import ff_utils
 
@@ -134,3 +135,89 @@ def keep_last_item(items: Sequence) -> Sequence:
     elif len(items) > 1:
         result = items[-1:]
     return result
+
+
+def get_library_from_file_set(fileset_accession, smaht_key):
+    """Get the library that is associated with a fileset
+
+    Args:
+        library (str): fileset accession
+        smaht_key (dict): SMaHT key
+
+    Raises:
+        Exception: Raises an exception when there are multiple libraried associated
+
+    Returns:
+        dict: Library item from portal
+    """
+    file_set = ff_utils.get_metadata(
+        fileset_accession, add_on="frame=raw&datastore=database", key=smaht_key
+    )
+    if len(file_set["libraries"] > 1):
+        raise Exception(f"Multiple libraries found for fileset {fileset_accession}")
+    library = ff_utils.get_metadata(
+        file_set["libraries"][0], add_on="frame=raw&datastore=database", key=smaht_key
+    )
+    return library
+
+def get_sample_from_library(library, smaht_key):
+    """Get the sample that is associated with a library
+
+    Args:
+        library (dict): library item from portal
+        smaht_key (dict): SMaHT key
+
+    Raises:
+        Exception: Raises an exception when there are multiple samples associated
+
+    Returns:
+        dict: Sample item from portal
+    """
+    analyte = ff_utils.get_metadata(
+        library["analyte"], add_on="frame=raw&datastore=database", key=smaht_key
+    )
+    if len(analyte["samples"] > 1):
+        raise Exception(f"Multiple samples found for library {library['accession']}")
+    sample = ff_utils.get_metadata(
+        analyte["samples"][0], add_on="frame=raw&datastore=database", key=smaht_key
+    )
+    return sample
+
+
+def get_latest_mwf(mwf_name, smaht_key):
+    """Gets the latest version of the MWF with name `mwf_name`
+
+    Args:
+        mwf_name (string): Name of the MWF
+        smaht_key (dcit): SMaHT key
+
+    Returns:
+        dict: MWF item from portal
+    """
+    query = f"/search/?type=MetaWorkflow&name={mwf_name}"
+    search_results = ff_utils.search_metadata(query, key=smaht_key)
+    
+    if len(search_results) == 0:
+        return None
+    
+    latest_result = search_results[0]
+    if len(search_results) == 1:
+        return latest_result
+    
+    # There are multiple MWFs. Get the latest version
+    for search_result in search_results:
+        if version.parse(latest_result["version"]) < version.parse(search_result["version"]):
+            latest_result = search_result
+    return latest_result
+
+
+def get_mwfr_file_input_arg(argument_name, files):
+    return {"argument_name": argument_name, "argument_type": "file", "files": files}
+
+
+def get_mwfr_parameter_input_arg(argument_name, value):
+    return {
+        "argument_name": argument_name,
+        "argument_type": "parameter",
+        "value": value,
+    }

--- a/magma_smaht/utils.py
+++ b/magma_smaht/utils.py
@@ -79,7 +79,7 @@ def chunk_ids(ids):
     result = []
     chunk_size = 5
     for idx in range(0, len(ids), chunk_size):
-        result.append(ids[idx: idx + chunk_size])
+        result.append(ids[idx : idx + chunk_size])
     return result
 
 
@@ -137,11 +137,11 @@ def keep_last_item(items: Sequence) -> Sequence:
     return result
 
 
-def get_library_from_file_set(fileset_accession, smaht_key):
+def get_library_from_file_set(file_set, smaht_key):
     """Get the library that is associated with a fileset
 
     Args:
-        library (str): fileset accession
+        file_set(dicr): fileset from portal
         smaht_key (dict): SMaHT key
 
     Raises:
@@ -150,15 +150,14 @@ def get_library_from_file_set(fileset_accession, smaht_key):
     Returns:
         dict: Library item from portal
     """
-    file_set = ff_utils.get_metadata(
-        fileset_accession, add_on="frame=raw&datastore=database", key=smaht_key
-    )
-    if len(file_set["libraries"] > 1):
-        raise Exception(f"Multiple libraries found for fileset {fileset_accession}")
+
+    if len(file_set["libraries"]) > 1:
+        raise Exception(f"Multiple libraries found for fileset {file_set['accession']}")
     library = ff_utils.get_metadata(
         file_set["libraries"][0], add_on="frame=raw&datastore=database", key=smaht_key
     )
     return library
+
 
 def get_sample_from_library(library, smaht_key):
     """Get the sample that is associated with a library
@@ -176,7 +175,7 @@ def get_sample_from_library(library, smaht_key):
     analyte = ff_utils.get_metadata(
         library["analyte"], add_on="frame=raw&datastore=database", key=smaht_key
     )
-    if len(analyte["samples"] > 1):
+    if len(analyte["samples"]) > 1:
         raise Exception(f"Multiple samples found for library {library['accession']}")
     sample = ff_utils.get_metadata(
         analyte["samples"][0], add_on="frame=raw&datastore=database", key=smaht_key
@@ -196,17 +195,19 @@ def get_latest_mwf(mwf_name, smaht_key):
     """
     query = f"/search/?type=MetaWorkflow&name={mwf_name}"
     search_results = ff_utils.search_metadata(query, key=smaht_key)
-    
+
     if len(search_results) == 0:
         return None
-    
+
     latest_result = search_results[0]
     if len(search_results) == 1:
         return latest_result
-    
+
     # There are multiple MWFs. Get the latest version
     for search_result in search_results:
-        if version.parse(latest_result["version"]) < version.parse(search_result["version"]):
+        if version.parse(latest_result["version"]) < version.parse(
+            search_result["version"]
+        ):
             latest_result = search_result
     return latest_result
 

--- a/magma_smaht/wfrutils.py
+++ b/magma_smaht/wfrutils.py
@@ -94,9 +94,9 @@ class FFWfrUtils(object):
             wfr_uuid = job_info.get('WorkflowRun uuid', '')
             if not wfr_uuid:
                 return None
-            self._metadata[job_id] = ff_utils.get_metadata(wfr_uuid, key=self.ff_key)
+            self._metadata[job_id] = ff_utils.get_metadata(wfr_uuid, add_on="frame=raw&datastore=database", key=self.ff_key)
             return self._metadata[job_id]
-
+        
     @property
     def ff_key(self):
         """Get access key for the portal.

--- a/poetry.lock
+++ b/poetry.lock
@@ -59,17 +59,17 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.34.48"
+version = "1.34.51"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "boto3-1.34.48-py3-none-any.whl", hash = "sha256:adc785ff05aec9fc93f82d507420b320203cd4fd011c67eb369b3aa2b5aeb298"},
-    {file = "boto3-1.34.48.tar.gz", hash = "sha256:f9873c3f03de546d7297475c6acd771840c385521caadb8c121a1ac38bc59cd4"},
+    {file = "boto3-1.34.51-py3-none-any.whl", hash = "sha256:67732634dc7d0afda879bd9a5e2d0818a2c14a98bef766b95a3e253ea5104cb9"},
+    {file = "boto3-1.34.51.tar.gz", hash = "sha256:2cd9463e738a184cbce8a6824027c22163c5f73e277a35ff5aa0fb0e845b4301"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.48,<1.35.0"
+botocore = ">=1.34.51,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -78,13 +78,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.48"
+version = "1.34.51"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "botocore-1.34.48-py3-none-any.whl", hash = "sha256:f3e1c84fa75fd6921dfbfb4b2f803bcc424b9b866982fe80e08edbd26ca9861c"},
-    {file = "botocore-1.34.48.tar.gz", hash = "sha256:eabdde36309274b76bb79ae9bdfa10c1fd91a2c9b3343cfa15b8a91f8e1ec224"},
+    {file = "botocore-1.34.51-py3-none-any.whl", hash = "sha256:01d5156247f991b3466a8404e3d7460a9ecbd9b214f9992d6ba797d9ddc6f120"},
+    {file = "botocore-1.34.51.tar.gz", hash = "sha256:5086217442e67dd9de36ec7e87a0c663f76b7790d5fb6a12de565af95e87e319"},
 ]
 
 [package.dependencies]
@@ -186,6 +186,20 @@ files = [
 
 [package.extras]
 unicode-backport = ["unicodedata2"]
+
+[[package]]
+name = "click"
+version = "8.1.7"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
@@ -533,13 +547,13 @@ test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 
 [[package]]
 name = "pytest"
-version = "8.0.1"
+version = "8.0.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.0.1-py3-none-any.whl", hash = "sha256:3e4f16fe1c0a9dc9d9389161c127c3edc5d810c38d6793042fb81d9f48a59fca"},
-    {file = "pytest-8.0.1.tar.gz", hash = "sha256:267f6563751877d772019b13aacbe4e860d73fe8f651f28112e9ac37de7513ae"},
+    {file = "pytest-8.0.2-py3-none-any.whl", hash = "sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096"},
+    {file = "pytest-8.0.2.tar.gz", hash = "sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd"},
 ]
 
 [package.dependencies]
@@ -889,13 +903,13 @@ telegram = ["requests"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.10.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
-    {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},
+    {file = "typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"},
+    {file = "typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"},
 ]
 
 [[package]]
@@ -984,4 +998,4 @@ tests = ["PasteDeploy", "WSGIProxy2", "coverage", "mock", "nose (<1.3.0)", "pyqu
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "9c858a20430bf07db87026e6872e6e9be2988b0951a0a0d1eb8928a48061e58a"
+content-hash = "8b0517f5cb9dd6c7f69c167bdf0c64213aa6ba216b32ac61fdfb9087eaadc881"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ packages = [
 python = ">=3.8,<3.12"
 dcicutils = "^8.0.0"
 tibanna-ff = "3.2.0"
+packaging = "^23.0"
+click = "^8.1.3"
 
 
 [tool.poetry.dev-dependencies]
@@ -32,7 +34,8 @@ pytest = "*"
 
 
 [tool.poetry.scripts]
-create-meta-workflow-run = "magma_ff.commands.create_meta_workflow_run:main"
+create-illumina-mwfr = "magma_smaht.create_metawfr:mwfr_illumina_alignment"
+create-fastqc-mwfr = "magma_smaht.create_metawfr:mwfr_fastqc"
 publish-to-pypi = "dcicutils.scripts.publish_to_pypi:main"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,11 @@ pytest = "*"
 
 
 [tool.poetry.scripts]
-create-illumina-mwfr = "magma_smaht.create_metawfr:mwfr_illumina_alignment"
-create-pacbio-mwfr = "magma_smaht.create_metawfr:mwfr_pacbio_alignment"
-create-fastqc-mwfr = "magma_smaht.create_metawfr:mwfr_fastqc"
+create-illumina-mwfr = "magma_smaht.commands.create_meta_workflow_run:mwfr_illumina_alignment_cmd"
+create-pacbio-mwfr = "magma_smaht.commands.create_meta_workflow_run:mwfr_pacbio_alignment_cmd"
+create-hic-mwfr = "magma_smaht.commands.create_meta_workflow_run:mwfr_hic_alignment_cmd"
+create-ont-mwfr = "magma_smaht.commands.create_meta_workflow_run:mwfr_ont_alignment_cmd"
+create-fastqc-mwfr = "magma_smaht.commands.create_meta_workflow_run:mwfr_fastqc_cmd"
 publish-to-pypi = "dcicutils.scripts.publish_to_pypi:main"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pytest = "*"
 
 [tool.poetry.scripts]
 create-illumina-mwfr = "magma_smaht.create_metawfr:mwfr_illumina_alignment"
+create-pacbio-mwfr = "magma_smaht.create_metawfr:mwfr_pacbio_alignment"
 create-fastqc-mwfr = "magma_smaht.create_metawfr:mwfr_fastqc"
 publish-to-pypi = "dcicutils.scripts.publish_to_pypi:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-suite"
-version = "3.1.0"
+version = "3.2.0"
 description = "Collection of tools to manage meta-workflows automation."
 authors = ["Michele Berselli <berselli.michele@gmail.com>", "Doug Rioux", "Soo Lee", "CGAP team"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ pytest = "*"
 
 
 [tool.poetry.scripts]
-create-illumina-mwfr = "magma_smaht.commands.create_meta_workflow_run:mwfr_illumina_alignment_cmd"
-create-pacbio-mwfr = "magma_smaht.commands.create_meta_workflow_run:mwfr_pacbio_alignment_cmd"
-create-hic-mwfr = "magma_smaht.commands.create_meta_workflow_run:mwfr_hic_alignment_cmd"
-create-ont-mwfr = "magma_smaht.commands.create_meta_workflow_run:mwfr_ont_alignment_cmd"
-create-fastqc-mwfr = "magma_smaht.commands.create_meta_workflow_run:mwfr_fastqc_cmd"
+create-illumina-mwfr-smaht = "magma_smaht.commands.create_meta_workflow_run:mwfr_illumina_alignment_cmd"
+create-pacbio-mwfr-smaht = "magma_smaht.commands.create_meta_workflow_run:mwfr_pacbio_alignment_cmd"
+create-hic-mwfr-smaht = "magma_smaht.commands.create_meta_workflow_run:mwfr_hic_alignment_cmd"
+create-ont-mwfr-smaht = "magma_smaht.commands.create_meta_workflow_run:mwfr_ont_alignment_cmd"
+create-fastqc-mwfr-smaht = "magma_smaht.commands.create_meta_workflow_run:mwfr_fastqc_cmd"
 publish-to-pypi = "dcicutils.scripts.publish_to_pypi:main"
 
 


### PR DESCRIPTION
This PR adds command line functionality to create MWFRs from file sets. The following commands have been added `create-illumina-mwfr`, `create-pacbio-mwfr`, `create-hic-mwfr`, `create-ont-mwfr`, `create-fastqc-mwfr`. In order to create a MWFR for an ONT data set (file set) with accession `SMAXXX` in the production account, you would run
```
create-ont-mwfr -f SMAXXX -e staging
```
where `staging` refers to the name of the environment in your `.smaht-keys.json` file.