### PR TITLE
Handle multiple analytes per library

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@
 Change Log
 ==========
 
+3.2.3
+=====
+* Update `magma_smaht` to accommodate data model change on Library from `analyte` to `analytes`
+
+
 3.2.2
 =====
 * Generalize tibanna-ff dependency

--- a/magma_smaht/utils.py
+++ b/magma_smaht/utils.py
@@ -186,13 +186,17 @@ def get_sample_from_library(library, smaht_key):
     Returns:
         dict: Sample item from portal
     """
-    analyte = ff_utils.get_metadata(
-        library["analyte"], add_on="frame=raw&datastore=database", key=smaht_key
-    )
-    if len(analyte["samples"]) > 1:
+    samples = []
+    analytes = library.get("analytes", [])
+    for analyte in analytes:
+        item = ff_utils.get_metadata(
+            analyte, add_on="frame=raw&datastore=database", key=smaht_key
+        )
+        samples += item.get("samples", [])
+    if len(set(samples)) > 1:
         raise Exception(f"Multiple samples found for library {library['accession']}")
     sample = ff_utils.get_metadata(
-        analyte["samples"][0], add_on="frame=raw&datastore=database", key=smaht_key
+        samples[0], add_on="frame=raw&datastore=database", key=smaht_key
     )
     return sample
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-suite"
-version = "3.2.2"
+version = "3.2.3"
 description = "Collection of tools to manage meta-workflows automation."
 authors = ["Michele Berselli <berselli.michele@gmail.com>", "Doug Rioux", "Soo Lee", "CGAP team"]
 license = "MIT"


### PR DESCRIPTION
This PR makes an update to `magma_smaht` to accommodate the corresponding breaking data model change permitting multiple analytes per library.