### PR TITLE
More wrangler utilities and options to create MWFRs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,11 +3,20 @@
 Change Log
 ==========
 
+3.8.0
+=====
+* Added possibility to overwrite exsting QCs when running a standalone QC workflow.
+* In QC workflows, it is now possible to specify multiple files or filesets at once. MetaworkflowRuns are created for each file or fileset.
+* Added a `custom_qc`` function. It has currently no functionality, but it can be used when custom MWFs are created by bioinformatics and need to be run
+* Added function to reset a list of MetaWorkflowRuns
+* Added function to merge QC items.
+* Updated RNA-specific input to Gencode 47
+
+
 3.7.0
 =====
 * Add support for BAM2FASTQ MetaWorkflowRun
 * Add RNA-Seq alignment MetaWorkflowRun
-
 
 
 3.6.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Change Log
 * Added function to reset a list of MetaWorkflowRuns
 * Added function to merge QC items.
 * Updated RNA-specific input to Gencode 47
+* Added function to archive unaligned reads within a fileset
 
 
 3.7.0

--- a/magma_smaht/commands/create_meta_workflow_run.py
+++ b/magma_smaht/commands/create_meta_workflow_run.py
@@ -14,7 +14,7 @@ from magma_smaht.create_metawfr import (
     mwfr_ultra_long_bamqc,
     mwfr_long_read_bamqc,
     mwfr_short_read_fastqc,
-    mwfr_custom_qc
+    mwfr_custom_qc,
 )
 from magma_smaht.utils import get_auth_key
 
@@ -133,15 +133,28 @@ def align_ont(fileset_accession, auth_env):
 @cli.command()
 @click.help_option("--help", "-h")
 @click.option(
-    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
+    "-f",
+    "--fileset-accessions",
+    required=True,
+    type=str,
+    multiple=True,
+    help="Fileset accession",
 )
 @click.option(
     "-c",
     "--check-lanes",
-    required=True,
-    default=True,
-    type=bool,
+    default=False,
+    is_flag=True,
+    show_default=True,
     help="Whether to check lanes or not (different MWFs)",
+)
+@click.option(
+    "-r",
+    "--replace-qc",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Replace existing QC items.",
 )
 @click.option(
     "-e",
@@ -150,10 +163,12 @@ def align_ont(fileset_accession, auth_env):
     type=str,
     help="Name of environment in smaht-keys file",
 )
-def qc_short_read_fastq_illumina(fileset_accession, check_lanes, auth_env):
+def qc_short_read_fastq_illumina(fileset_accessions, check_lanes, replace_qc, auth_env):
     """QC MWFR for paired short-read Illumina FASTQs"""
     smaht_key = get_auth_key(auth_env)
-    mwfr_fastqc(fileset_accession, check_lanes, smaht_key)
+    for fileset_accession in fileset_accessions:
+        print(f"Working on Fileset {fileset_accession}")
+        mwfr_fastqc(fileset_accession, check_lanes, replace_qc, smaht_key)
 
 
 @cli.command()
@@ -175,7 +190,20 @@ def qc_short_read_fastq(file_accession, auth_env):
 @cli.command()
 @click.help_option("--help", "-h")
 @click.option(
-    "-f", "--fileset-accession", required=True, type=str, help="Fileset accession"
+    "-f",
+    "--fileset-accessions",
+    required=True,
+    type=str,
+    multiple=True,
+    help="Fileset accession",
+)
+@click.option(
+    "-r",
+    "--replace-qc",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Replace existing QC items.",
 )
 @click.option(
     "-e",
@@ -184,10 +212,12 @@ def qc_short_read_fastq(file_accession, auth_env):
     type=str,
     help="Name of environment in smaht-keys file",
 )
-def qc_long_read_ubam(fileset_accession, auth_env):
+def qc_long_read_ubam(fileset_accessions, replace_qc, auth_env):
     """QC MWFR for unaligned long-read BAMs"""
     smaht_key = get_auth_key(auth_env)
-    mwfr_ubam_qc_long_read(fileset_accession, smaht_key)
+    for fileset_accession in fileset_accessions:
+        print(f"Working on Fileset {fileset_accession}")
+        mwfr_ubam_qc_long_read(fileset_accession, replace_qc, smaht_key)
 
 
 @cli.command()
@@ -217,14 +247,29 @@ def qc_short_read_bam(file_accession, auth_env):
     help="Name of environment in smaht-keys file",
 )
 def custom_qc(file_accession, auth_env):
-    """Custom QC MWFR """
+    """Custom QC MWFR"""
     smaht_key = get_auth_key(auth_env)
     mwfr_custom_qc(file_accession, smaht_key)
 
 
 @cli.command()
 @click.help_option("--help", "-h")
-@click.option("-f", "--file-accession", required=True, type=str, help="File accession")
+@click.option(
+    "-f",
+    "--file-accessions",
+    required=True,
+    type=str,
+    multiple=True,
+    help="File accession(s)",
+)
+@click.option(
+    "-r",
+    "--replace-qc",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Replace existing QC items.",
+)
 @click.option(
     "-e",
     "--auth-env",
@@ -232,15 +277,25 @@ def custom_qc(file_accession, auth_env):
     type=str,
     help="Name of environment in smaht-keys file",
 )
-def qc_ultra_long_bam(file_accession, auth_env):
+def qc_ultra_long_bam(file_accessions, replace_qc, auth_env):
     """QC MWFR for aligned, ultra-long BAMs (ONT)"""
     smaht_key = get_auth_key(auth_env)
-    mwfr_ultra_long_bamqc(file_accession, smaht_key)
+    for file_accession in file_accessions:
+        print(f"Working on File {file_accession}")
+        mwfr_ultra_long_bamqc(file_accession, replace_qc, smaht_key)
 
 
 @cli.command()
 @click.help_option("--help", "-h")
-@click.option("-f", "--file-accession", required=True, type=str, help="File accession")
+@click.option("-f", "--file-accessions", required=True, type=str, multiple=True, help="File accession(s)")
+@click.option(
+    "-r",
+    "--replace-qc",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Replace existing QC items.",
+)
 @click.option(
     "-e",
     "--auth-env",
@@ -248,10 +303,12 @@ def qc_ultra_long_bam(file_accession, auth_env):
     type=str,
     help="Name of environment in smaht-keys file",
 )
-def qc_long_read_bam(file_accession, auth_env):
+def qc_long_read_bam(file_accessions, replace_qc, auth_env):
     """QC MWFR for aligned, long-read BAMs (PacBio)"""
     smaht_key = get_auth_key(auth_env)
-    mwfr_long_read_bamqc(file_accession, smaht_key)
+    for file_accession in file_accessions:
+        print(f"Working on File {file_accession}")
+        mwfr_long_read_bamqc(file_accession, replace_qc, smaht_key)
 
 
 @cli.command()

--- a/magma_smaht/commands/create_meta_workflow_run.py
+++ b/magma_smaht/commands/create_meta_workflow_run.py
@@ -14,6 +14,7 @@ from magma_smaht.create_metawfr import (
     mwfr_ultra_long_bamqc,
     mwfr_long_read_bamqc,
     mwfr_short_read_fastqc,
+    mwfr_custom_qc
 )
 from magma_smaht.utils import get_auth_key
 
@@ -203,6 +204,22 @@ def qc_short_read_bam(file_accession, auth_env):
     """QC MWFR for aligned short-read BAMs"""
     smaht_key = get_auth_key(auth_env)
     mwfr_bamqc_short_read(file_accession, smaht_key)
+
+
+@cli.command()
+@click.help_option("--help", "-h")
+@click.option("-f", "--file-accession", required=True, type=str, help="File accession")
+@click.option(
+    "-e",
+    "--auth-env",
+    required=True,
+    type=str,
+    help="Name of environment in smaht-keys file",
+)
+def custom_qc(file_accession, auth_env):
+    """Custom QC MWFR """
+    smaht_key = get_auth_key(auth_env)
+    mwfr_custom_qc(file_accession, smaht_key)
 
 
 @cli.command()

--- a/magma_smaht/commands/wrangler_utils.py
+++ b/magma_smaht/commands/wrangler_utils.py
@@ -97,10 +97,11 @@ def reset_all_failed_mwfrs(auth_env):
 @click.help_option("--help", "-h")
 @click.option(
     "-f",
-    "--file-accession",
+    "--file-accessions",
     required=True,
     type=str,
-    help="File accession",
+    multiple=True,
+    help="File accessions",
 )
 @click.option(
     "-m",
@@ -116,10 +117,17 @@ def reset_all_failed_mwfrs(auth_env):
     type=str,
     help="Name of environment in smaht-keys file",
 )
-def merge_qc_items(file_accession, mode, auth_env):
-    """Reset a list of MetaWorkflowRuns"""
+def merge_qc_items(file_accessions, mode, auth_env):
+    """
+    Merged QC items of a file.
+    Mode "keep_oldest" will merge the qc values and patch them to the oldest qc_item. The other qc_items will be removed from the file
+    Mode "keep_newest" will merge the qc values and patch them to the newest qc_item. The other qc_items will be removed from the file
+    In general, QC values of newer QC items will overwrite existing QC values of older items
+    """
     smaht_key = get_auth_key(auth_env)
-    wrangler_utils.merge_qc_items(file_accession, mode, smaht_key)
+    for f in file_accessions:
+        print(f"Working on {f}")
+        wrangler_utils.merge_qc_items(f, mode, smaht_key)
 
 
 @cli.command()

--- a/magma_smaht/commands/wrangler_utils.py
+++ b/magma_smaht/commands/wrangler_utils.py
@@ -119,7 +119,7 @@ def reset_all_failed_mwfrs(auth_env):
 )
 def merge_qc_items(file_accessions, mode, auth_env):
     """
-    Merged QC items of a file.
+    Merge QC items of a file.
     Mode "keep_oldest" will merge the qc values and patch them to the oldest qc_item. The other qc_items will be removed from the file
     Mode "keep_newest" will merge the qc values and patch them to the newest qc_item. The other qc_items will be removed from the file
     In general, QC values of newer QC items will overwrite existing QC values of older items
@@ -128,6 +128,34 @@ def merge_qc_items(file_accessions, mode, auth_env):
     for f in file_accessions:
         print(f"Working on {f}")
         wrangler_utils.merge_qc_items(f, mode, smaht_key)
+
+
+@cli.command()
+@click.help_option("--help", "-h")
+@click.option(
+    "-f",
+    "--fileset-accessions",
+    required=True,
+    type=str,
+    multiple=True,
+    help="Fileset accessions",
+)
+@click.option(
+    "-e",
+    "--auth-env",
+    required=True,
+    type=str,
+    help="Name of environment in smaht-keys file",
+)
+def archive_unaligned_reads(fileset_accessions, auth_env):
+    """
+    Archive (submitted) unaligned reads of a fileset. 
+    Every submitted unaligned read in the fileset will receive the s3_lifecycle_categor=short_term_archive.
+    """
+    smaht_key = get_auth_key(auth_env)
+    for f in fileset_accessions:
+        print(f"Working on Fileset {f}")
+        wrangler_utils.archive_unaligned_reads(f, smaht_key)
 
 
 @cli.command()

--- a/magma_smaht/commands/wrangler_utils.py
+++ b/magma_smaht/commands/wrangler_utils.py
@@ -58,6 +58,29 @@ def reset_failed_mwfrs(mwfr_uuids, auth_env):
 @cli.command()
 @click.help_option("--help", "-h")
 @click.option(
+    "-m",
+    "--mwfr-uuids",
+    required=True,
+    type=str,
+    multiple=True,
+    help="List of MWFRs to reset",
+)
+@click.option(
+    "-e",
+    "--auth-env",
+    required=True,
+    type=str,
+    help="Name of environment in smaht-keys file",
+)
+def reset_mwfrs(mwfr_uuids, auth_env):
+    """Reset a list of MetaWorkflowRuns"""
+    smaht_key = get_auth_key(auth_env)
+    wrangler_utils.reset_mwfrs(mwfr_uuids, smaht_key)
+
+
+@cli.command()
+@click.help_option("--help", "-h")
+@click.option(
     "-e",
     "--auth-env",
     required=True,
@@ -68,6 +91,35 @@ def reset_all_failed_mwfrs(auth_env):
     """Reset all failed MetaWorkflowRuns on the portal"""
     smaht_key = get_auth_key(auth_env)
     wrangler_utils.reset_all_failed_mwfrs(smaht_key)
+
+
+@cli.command()
+@click.help_option("--help", "-h")
+@click.option(
+    "-f",
+    "--file-accession",
+    required=True,
+    type=str,
+    help="File accession",
+)
+@click.option(
+    "-m",
+    "--mode",
+    required=True,
+    type=click.Choice(['keep_oldest', 'keep_newest']),
+    help="Merge mode",
+)
+@click.option(
+    "-e",
+    "--auth-env",
+    required=True,
+    type=str,
+    help="Name of environment in smaht-keys file",
+)
+def merge_qc_items(file_accession, mode, auth_env):
+    """Reset a list of MetaWorkflowRuns"""
+    smaht_key = get_auth_key(auth_env)
+    wrangler_utils.merge_qc_items(file_accession, mode, smaht_key)
 
 
 @cli.command()

--- a/magma_smaht/scripts/run_bioinformatics_test_mwfrs.sh
+++ b/magma_smaht/scripts/run_bioinformatics_test_mwfrs.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Run alignment metaworkflow runs on the test data
+# Test data; https://data.smaht.org/search/?type=FileSet&tags=bioinformatics_test
+
+#smaht:MetaWorkflow-Hi-C_alignment_GRCh38_<version>
+create-mwfr-smaht align-hic -e data -f SMAFSOYAP5B1
+#smaht:MetaWorkflow-Illumina_alignment_GRCh38_<version>
+create-mwfr-smaht align-illumina -e data -l 151 -f SMAFSU6J1YW4
+#smaht:MetaWorkflow-ONT_alignment_GRCh38_<version>
+create-mwfr-smaht align-ont -e data -f SMAFS2ROFA22
+#smaht:MetaWorkflow-PacBio_alignment_GRCh38_<version>
+create-mwfr-smaht align-pacbio -e data -f SMAFSBZ1Y9JL
+#smaht:MetaWorkflow-RNA-seq_bulk_short_reads_GRCh38_<version>
+create-mwfr-smaht align-rnaseq -e data -l 151 -f SMAFS9HC8D37
+
+# Run standalone QC metaworkflows on the test data
+
+#smaht:MetaWorkflow-short_reads_FASTQ_quality_metrics_<version>
+create-mwfr-smaht qc-short-read-fastq-illumina -e data -f SMAFSU6J1YW4 -c
+#smaht:MetaWorkflow-Illumina_FASTQ_quality_metrics_<version>
+create-mwfr-smaht qc-short-read-fastq-illumina -e data -f SMAFSU6J1YW4
+#smaht:MetaWorkflow-long_reads_FASTQ_quality_metrics_<version> (ONT, PacBio)
+create-mwfr-smaht qc-long-read-ubam -e data -f SMAFSBZ1Y9JL
+#smaht:MetaWorkflow-paired-end_short_reads_BAM_quality_metrics_GRCh38_<version>
+create-mwfr-smaht qc-short-read-bam -e data -f SMAFIMBZZEFZ
+#smaht:MetaWorkflow-ultra-long_reads_BAM_quality_metrics_GRCh38_<version> (ONT)
+create-mwfr-smaht qc-ultra-long-bam -e data -f SMAFIYR538JO
+#smaht:MetaWorkflow-long_reads_BAM_quality_metrics_GRCh38_<version> (PacBio)
+create-mwfr-smaht qc-long-read-bam -e data -f SMAFIPWXKYCL
+
+#smaht:MetaWorkflow-sample_identity_check_<version>
+# TODO

--- a/magma_smaht/wrangler_utils.py
+++ b/magma_smaht/wrangler_utils.py
@@ -144,7 +144,7 @@ def merge_qc_items(file_accession: str, mode: str, smaht_key: dict):
     file = ff_utils.get_metadata(file_accession, smaht_key)
     file_uuid = file["uuid"]
     file_qms = file.get("quality_metrics", [])
-    if len(file_qms) < 0:
+    if len(file_qms) < 2:
         print(f"ERROR: Not enough QM items present for merging.")
         return
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-suite"
-version = "3.7.0"
+version = "3.8.0"
 description = "Collection of tools to manage meta-workflows automation."
 authors = ["Michele Berselli <berselli.michele@gmail.com>", "Doug Rioux", "Soo Lee", "CGAP team"]
 license = "MIT"


### PR DESCRIPTION
This PR
- adds possibility to overwrite the exsting QCs when running a standalone QC workflow.
- in QC workflows, it is now possible to specify multiple files or filesets at once. MetaworkflowRuns are created for each file or fileset
- Added a `custom_qc` function. It does nothing right now, but it can be used when custom MWFs are created by bioinformatics and need to be run
- Added function to reset a list of MetaWorkflowRuns
- Added function to merge QC items.
- Updated RNA-specific input to Gencode 47